### PR TITLE
#27 Screen navigation setup

### DIFF
--- a/lib/src/configs/routes.dart
+++ b/lib/src/configs/routes.dart
@@ -1,11 +1,19 @@
+import 'package:dr_app/src/screens/cart_screen.dart';
 import 'package:dr_app/src/screens/category_detail_screen.dart';
+import 'package:dr_app/src/screens/explore_screen.dart';
 import 'package:dr_app/src/screens/home_screen.dart';
+import 'package:dr_app/src/screens/more_screen.dart';
 import 'package:dr_app/src/screens/outlet_detail_screen.dart';
+import 'package:dr_app/src/screens/profile_screen.dart';
 import 'package:dr_app/src/screens/scanner_screen.dart';
 import 'package:flutter/widgets.dart';
 
 final Map<String, WidgetBuilder> routes = {
   HomeScreen.id: (context) => HomeScreen(),
+  ExploreScreen.id: (context) => ExploreScreen(),
+  CartScreen.id: (context) => CartScreen(),
+  ProfileScreen.id: (context) => ProfileScreen(),
+  MoreScreen.id: (context) => MoreScreen(),
   ScannerScreen.id: (context) => ScannerScreen(),
   OutletDetailScreen.id: (context) => OutletDetailScreen(),
   CategoryDetailScreen.id: (context) => CategoryDetailScreen(),

--- a/lib/src/configs/theme.dart
+++ b/lib/src/configs/theme.dart
@@ -3,5 +3,5 @@ import 'package:flutter/material.dart';
 ThemeData getAppTheme() => ThemeData(
       primarySwatch: Colors.blue,
       visualDensity: VisualDensity.adaptivePlatformDensity,
-      scaffoldBackgroundColor: Colors.green,
+      scaffoldBackgroundColor: Colors.white,
     );

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -1,6 +1,5 @@
-import 'package:dr_app/src/configs/routes.dart';
 import 'package:dr_app/src/configs/theme.dart';
-import 'package:dr_app/src/screens/home_screen.dart';
+import 'package:dr_app/src/navigation/root_container.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(MyApp());
@@ -10,8 +9,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: getAppTheme(),
-      initialRoute: HomeScreen.id,
-      routes: routes,
+      home: RootContainer(),
     );
   }
 }

--- a/lib/src/navigation/navigatior_container.dart
+++ b/lib/src/navigation/navigatior_container.dart
@@ -3,6 +3,8 @@ import 'package:dr_app/src/navigation/screen_navigator_observer.dart';
 import 'package:dr_app/src/navigation/tab_data.dart';
 import 'package:flutter/material.dart';
 
+/// A top-level composition of [Navigator] that enables
+/// dedicated nested routing for each [BottomNavigationBarItem]
 class NavigatorContainer extends StatefulWidget {
   const NavigatorContainer({Key key, this.tabData, this.onNavigation})
       : super(key: key);

--- a/lib/src/navigation/navigatior_container.dart
+++ b/lib/src/navigation/navigatior_container.dart
@@ -1,0 +1,36 @@
+import 'package:dr_app/src/configs/routes.dart';
+import 'package:dr_app/src/navigation/screen_navigator_observer.dart';
+import 'package:dr_app/src/navigation/tab_data.dart';
+import 'package:flutter/material.dart';
+
+class NavigatorContainer extends StatefulWidget {
+  const NavigatorContainer({Key key, this.tabData, this.onNavigation})
+      : super(key: key);
+
+  final TabData tabData;
+  final VoidCallback onNavigation;
+
+  @override
+  _NavigatorContainerState createState() => _NavigatorContainerState();
+}
+
+class _NavigatorContainerState extends State<NavigatorContainer> {
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      observers: <NavigatorObserver>[
+        ViewNavigatorObserver(widget.onNavigation),
+      ],
+      onGenerateRoute: (settings) {
+        return MaterialPageRoute(
+          settings: settings,
+          builder: (context) {
+            final rootId =
+                settings.name == '/' ? widget.tabData.rootId : settings.name;
+            return routes[rootId](context);
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/src/navigation/root_container.dart
+++ b/lib/src/navigation/root_container.dart
@@ -4,6 +4,8 @@ import 'package:dr_app/src/navigation/tabs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
+/// This class represents the application UI shell. It initiates the [BottomNavigationBar]
+/// with a set of [BottomNavigationBarItem] and manages the navigation between tabs.
 class RootContainer extends StatefulWidget {
   @override
   _RootContainerState createState() => _RootContainerState();

--- a/lib/src/navigation/root_container.dart
+++ b/lib/src/navigation/root_container.dart
@@ -1,0 +1,118 @@
+import 'package:dr_app/src/navigation/navigatior_container.dart';
+import 'package:dr_app/src/navigation/tab_data.dart';
+import 'package:dr_app/src/navigation/tabs.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+class RootContainer extends StatefulWidget {
+  @override
+  _RootContainerState createState() => _RootContainerState();
+}
+
+class _RootContainerState extends State<RootContainer>
+    with TickerProviderStateMixin<RootContainer> {
+  List<Key> _destinationKeys;
+  List<AnimationController> _faders;
+  AnimationController _hide;
+  int _currentIndex = 0;
+
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification.depth == 0) {
+      if (notification is UserScrollNotification) {
+        final UserScrollNotification userScroll = notification;
+        switch (userScroll.direction) {
+          case ScrollDirection.forward:
+            _hide.forward();
+            break;
+          case ScrollDirection.reverse:
+            _hide.reverse();
+            break;
+          case ScrollDirection.idle:
+            break;
+        }
+      }
+    }
+    return false;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _faders = tabs.map<AnimationController>((TabData destination) {
+      return AnimationController(
+          vsync: this, duration: Duration(milliseconds: 200));
+    }).toList();
+    _faders[_currentIndex].value = 1.0;
+    _destinationKeys =
+        List<Key>.generate(tabs.length, (int index) => GlobalKey()).toList();
+    _hide = AnimationController(vsync: this, duration: kThemeAnimationDuration);
+  }
+
+  @override
+  void dispose() {
+    for (AnimationController controller in _faders) controller.dispose();
+    _hide.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<ScrollNotification>(
+      onNotification: _handleScrollNotification,
+      child: Scaffold(
+        body: SafeArea(
+          top: false,
+          child: Stack(
+            fit: StackFit.expand,
+            children: tabs.map((TabData tabData) {
+              final Widget view = FadeTransition(
+                opacity: _faders[tabData.index]
+                    .drive(CurveTween(curve: Curves.fastOutSlowIn)),
+                child: KeyedSubtree(
+                  key: _destinationKeys[tabData.index],
+                  child: NavigatorContainer(
+                    tabData: tabData,
+                    onNavigation: () {
+                      _hide.forward();
+                    },
+                  ),
+                ),
+              );
+              if (tabData.index == _currentIndex) {
+                _faders[tabData.index].forward();
+                return view;
+              } else {
+                _faders[tabData.index].reverse();
+                if (_faders[tabData.index].isAnimating) {
+                  return IgnorePointer(child: view);
+                }
+                return Offstage(child: view);
+              }
+            }).toList(),
+          ),
+        ),
+        bottomNavigationBar: ClipRect(
+          child: SizeTransition(
+            sizeFactor: _hide,
+            axisAlignment: -1.0,
+            child: BottomNavigationBar(
+              currentIndex: _currentIndex,
+              onTap: (int index) {
+                setState(() {
+                  _currentIndex = index;
+                });
+              },
+              items: tabs.map((TabData destination) {
+                return BottomNavigationBarItem(
+                    icon: Icon(destination.icon),
+                    backgroundColor: destination.color,
+                    title: Text(destination.title));
+              }).toList(),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/navigation/screen_navigator_observer.dart
+++ b/lib/src/navigation/screen_navigator_observer.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class ViewNavigatorObserver extends NavigatorObserver {
+  ViewNavigatorObserver(this.onNavigation);
+
+  final VoidCallback onNavigation;
+
+  void didPop(Route<dynamic> route, Route<dynamic> previousRoute) {
+    onNavigation();
+  }
+
+  void didPush(Route<dynamic> route, Route<dynamic> previousRoute) {
+    onNavigation();
+  }
+}

--- a/lib/src/navigation/screen_navigator_observer.dart
+++ b/lib/src/navigation/screen_navigator_observer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+/// A [NavigatorObserver] that redirects push and pop events to the onNavigation callback.
 class ViewNavigatorObserver extends NavigatorObserver {
   ViewNavigatorObserver(this.onNavigation);
 

--- a/lib/src/navigation/tab_data.dart
+++ b/lib/src/navigation/tab_data.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+/// A model representing the information from a Tab item.
 class TabData {
   final int index;
   final String rootId;

--- a/lib/src/navigation/tab_data.dart
+++ b/lib/src/navigation/tab_data.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class TabData {
+  final int index;
+  final String rootId;
+  final String title;
+  final IconData icon;
+  final MaterialColor color;
+
+  const TabData(this.index, this.rootId, this.title, this.icon, this.color);
+}

--- a/lib/src/navigation/tabs.dart
+++ b/lib/src/navigation/tabs.dart
@@ -1,0 +1,13 @@
+import 'package:dr_app/src/navigation/tab_data.dart';
+import 'package:dr_app/src/screens/explore_screen.dart';
+import 'package:dr_app/src/screens/home_screen.dart';
+import 'package:dr_app/src/screens/more_screen.dart';
+import 'package:dr_app/src/screens/profile_screen.dart';
+import 'package:flutter/material.dart';
+
+const List<TabData> tabs = <TabData>[
+  TabData(0, HomeScreen.id, 'Home', Icons.restaurant, Colors.teal),
+  TabData(1, ExploreScreen.id, 'Explore', Icons.explore, Colors.cyan),
+  TabData(2, ProfileScreen.id, 'Profile', Icons.person_pin, Colors.orange),
+  TabData(3, MoreScreen.id, 'More', Icons.more_horiz, Colors.blue)
+];

--- a/lib/src/navigation/tabs.dart
+++ b/lib/src/navigation/tabs.dart
@@ -5,6 +5,7 @@ import 'package:dr_app/src/screens/more_screen.dart';
 import 'package:dr_app/src/screens/profile_screen.dart';
 import 'package:flutter/material.dart';
 
+/// A list of TabData used for configuring the application's [BottomNavigationBar].
 const List<TabData> tabs = <TabData>[
   TabData(0, HomeScreen.id, 'Home', Icons.restaurant, Colors.teal),
   TabData(1, ExploreScreen.id, 'Explore', Icons.explore, Colors.cyan),

--- a/lib/src/screens/cart_screen.dart
+++ b/lib/src/screens/cart_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class CartScreen extends StatelessWidget {
+  static const id = 'cart_screen';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(child: Center(child: Text('Cart Screen')));
+  }
+}

--- a/lib/src/screens/explore_screen.dart
+++ b/lib/src/screens/explore_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class ExploreScreen extends StatelessWidget {
+  static const id = 'explore_screen';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(child: Center(child: Text('Explore Screen')));
+  }
+}

--- a/lib/src/screens/home_screen.dart
+++ b/lib/src/screens/home_screen.dart
@@ -1,10 +1,14 @@
-//import 'package:dr_app/src/components/buttons/solid_button.dart';
 import 'package:dr_app/src/components/buttons/slider_button.dart';
 import 'package:flutter/material.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   static const id = 'home_screen';
 
+  @override
+  _HomeScreenState createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/src/screens/home_screen.dart
+++ b/lib/src/screens/home_screen.dart
@@ -1,4 +1,3 @@
-import 'package:dr_app/src/components/buttons/slider_button.dart';
 import 'package:flutter/material.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -13,14 +12,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Container(
-        child: Center(
-            child: LUSliderButton(
-          title: "check-in",
-          semanticTitle: 'check-in',
-          onSlided: () {
-            print('Slided!');
-          },
-        )),
+        child: Center(child: Text('Home Screen')),
       ),
     );
   }

--- a/lib/src/screens/more_screen.dart
+++ b/lib/src/screens/more_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class MoreScreen extends StatelessWidget {
+  static const id = 'more_screen';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(child: Center(child: Text('More Screen')));
+  }
+}

--- a/lib/src/screens/profile_screen.dart
+++ b/lib/src/screens/profile_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class ProfileScreen extends StatelessWidget {
+  static const id = 'profile_screen';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(child: Center(child: Text('Profile Screen')));
+  }
+}


### PR DESCRIPTION
# Screen navigation setup

- Create `ExploreScreen`, `CartScreen`, `ProfileScreen`, and `MoreScreen` scaffoldings.
- Register new routes for `ExploreScreen`, `CartScreen`, `ProfileScreen`, and `MoreScreen`.
- Register new routes for `ExploreScreen`, `CartScreen`, `ProfileScreen`, and `MoreScreen`.
- Turn the `HomeScreen` into a `StatefulWidget`.
- Create the `TabData` model.
- Configure the app tabs through the `tabs.dart` file.
- Create `NavigatorContainer`, `NavigatorObserver`, and `RootContainer` to manage tab navigation.
- Add documentation.
