### PR TITLE
#38 Product Screen

### DIFF
--- a/lib/components/counter.dart
+++ b/lib/components/counter.dart
@@ -1,6 +1,7 @@
 import 'package:dr_app/utils/colors.dart';
 import 'package:flutter/material.dart';
 
+///
 class LUCounter extends StatefulWidget {
   final Function onUpdate;
 

--- a/lib/components/counter.dart
+++ b/lib/components/counter.dart
@@ -16,7 +16,6 @@ class _LUCounterState extends State<LUCounter> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 150,
       height: 40,
       decoration: BoxDecoration(
           color: LUColors.smoothGray,
@@ -32,12 +31,19 @@ class _LUCounterState extends State<LUCounter> {
             }
           }),
           _buildDivider(),
-          Text(
-            _counter.toString(),
-            style: TextStyle(
-                fontSize: 22,
-                color: LUColors.darkBlue,
-                fontWeight: FontWeight.bold),
+          SizedBox(
+            width: 50,
+            height: 40,
+            child: Center(
+              child: Text(
+                _counter.toString(),
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                    fontSize: 22,
+                    color: LUColors.darkBlue,
+                    fontWeight: FontWeight.bold),
+              ),
+            ),
           ),
           _buildDivider(),
           _buildCounterButton(Icons.add, () {
@@ -52,11 +58,15 @@ class _LUCounterState extends State<LUCounter> {
   Widget _buildCounterButton(IconData icon, Function onPressed) => Material(
         color: Colors.transparent,
         child: InkWell(
-          borderRadius: BorderRadius.all(Radius.circular(40.0)),
+          borderRadius: BorderRadius.all(Radius.circular(8.0)),
           onTap: onPressed,
-          child: Icon(
-            icon,
-            color: LUColors.darkBlue,
+          child: SizedBox(
+            width: 50,
+            height: 40,
+            child: Icon(
+              icon,
+              color: LUColors.darkBlue,
+            ),
           ),
         ),
       );

--- a/lib/components/counter.dart
+++ b/lib/components/counter.dart
@@ -1,0 +1,56 @@
+import 'package:dr_app/utils/colors.dart';
+import 'package:flutter/material.dart';
+
+class LUCounter extends StatefulWidget {
+  @override
+  _LUCounterState createState() => _LUCounterState();
+}
+
+class _LUCounterState extends State<LUCounter> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 150,
+      height: 40,
+      decoration: BoxDecoration(
+          color: LUColors.smoothGray,
+          borderRadius: BorderRadius.all(Radius.circular(8.0))),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          _buildCounterButton(Icons.remove, () {}),
+          _buildDivider(),
+          Text(
+            '2',
+            style: TextStyle(
+                fontSize: 22,
+                color: LUColors.darkBlue,
+                fontWeight: FontWeight.bold),
+          ),
+          _buildDivider(),
+          _buildCounterButton(Icons.add, () {}),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCounterButton(IconData icon, Function onPressed) => Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.all(Radius.circular(40.0)),
+          onTap: onPressed,
+          child: Icon(
+            icon,
+            color: LUColors.darkBlue,
+          ),
+        ),
+      );
+
+  Widget _buildDivider() => VerticalDivider(
+        width: 4,
+        indent: 4,
+        endIndent: 4,
+        color: const Color(0X443C3C43),
+      );
+}

--- a/lib/components/counter.dart
+++ b/lib/components/counter.dart
@@ -2,11 +2,17 @@ import 'package:dr_app/utils/colors.dart';
 import 'package:flutter/material.dart';
 
 class LUCounter extends StatefulWidget {
+  final Function onUpdate;
+
+  const LUCounter({Key key, @required this.onUpdate}) : super(key: key);
+
   @override
   _LUCounterState createState() => _LUCounterState();
 }
 
 class _LUCounterState extends State<LUCounter> {
+  int _counter = 0;
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -19,17 +25,25 @@ class _LUCounterState extends State<LUCounter> {
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
-          _buildCounterButton(Icons.remove, () {}),
+          _buildCounterButton(Icons.remove, () {
+            if (_counter - 1 >= 0) {
+              setState(() => _counter--);
+              widget.onUpdate(_counter);
+            }
+          }),
           _buildDivider(),
           Text(
-            '2',
+            _counter.toString(),
             style: TextStyle(
                 fontSize: 22,
                 color: LUColors.darkBlue,
                 fontWeight: FontWeight.bold),
           ),
           _buildDivider(),
-          _buildCounterButton(Icons.add, () {}),
+          _buildCounterButton(Icons.add, () {
+            setState(() => _counter++);
+            widget.onUpdate(_counter);
+          }),
         ],
       ),
     );

--- a/lib/components/section.dart
+++ b/lib/components/section.dart
@@ -1,0 +1,41 @@
+import 'package:dr_app/utils/styles.dart';
+import 'package:flutter/material.dart';
+
+/// A container for a screen section. Automatically styles the
+/// given title and the relevant margins.
+class LUSection extends StatelessWidget {
+  final String title;
+  final Widget child;
+  final EdgeInsetsGeometry margin;
+  final EdgeInsetsGeometry titlePadding;
+
+  const LUSection(
+      {Key key,
+      @required this.title,
+      @required this.child,
+      this.margin = const EdgeInsets.only(top: 16.0),
+      this.titlePadding = const EdgeInsets.only(left: 18.0, bottom: 8.0)})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: margin ?? EdgeInsets.zero,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: titlePadding,
+            child: Text(
+              title,
+              style: Styles.section,
+            ),
+          ),
+          child,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/section.dart
+++ b/lib/components/section.dart
@@ -30,7 +30,7 @@ class LUSection extends StatelessWidget {
             padding: titlePadding,
             child: Text(
               title,
-              style: Styles.section,
+              style: Styles.sectionText,
             ),
           ),
           child,

--- a/lib/components/swiper.dart
+++ b/lib/components/swiper.dart
@@ -1,4 +1,5 @@
 import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_page_indicator/flutter_page_indicator.dart';
@@ -15,10 +16,16 @@ class LUSwiper extends StatelessWidget {
   Widget build(BuildContext context) {
     return Swiper(
       itemBuilder: (BuildContext context, int index) {
-        return FadeInImage.assetNetwork(
-          placeholder: Images.horizontalPlaceholder,
-          image: images[index],
-          fit: BoxFit.cover,
+        return Container(
+          color: LUColors.smoothGray,
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: FadeInImage.assetNetwork(
+              placeholder: Images.horizontalPlaceholder,
+              image: images[index],
+              fit: BoxFit.cover,
+            ),
+          ),
         );
       },
       indicatorLayout: PageIndicatorLayout.SCALE,

--- a/lib/components/swiper.dart
+++ b/lib/components/swiper.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_page_indicator/flutter_page_indicator.dart';
+import 'package:flutter_swiper/flutter_swiper.dart';
+
+const List<String> images = [
+  'https://picsum.photos/200/400',
+  'https://picsum.photos/200/500',
+  'https://picsum.photos/200/200'
+];
+
+class LUSwiper extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Swiper(
+      itemBuilder: (BuildContext context, int index) {
+        return Image.network(
+          images[index],
+          fit: BoxFit.fill,
+        );
+      },
+      indicatorLayout: PageIndicatorLayout.SCALE,
+      autoplay: false,
+      itemCount: images.length,
+      pagination: SwiperPagination(),
+    );
+  }
+}

--- a/lib/components/swiper.dart
+++ b/lib/components/swiper.dart
@@ -5,13 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_page_indicator/flutter_page_indicator.dart';
 import 'package:flutter_swiper/flutter_swiper.dart';
 
-const List<String> images = [
-  'https://picsum.photos/200/400',
-  'https://picsum.photos/200/500',
-  'https://picsum.photos/200/200'
-];
-
 class LUSwiper extends StatelessWidget {
+  final List<String> imgSrcList;
+
+  const LUSwiper({Key key, this.imgSrcList}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Swiper(
@@ -22,7 +20,7 @@ class LUSwiper extends StatelessWidget {
             padding: const EdgeInsets.only(bottom: 6),
             child: FadeInImage.assetNetwork(
               placeholder: Images.horizontalPlaceholder,
-              image: images[index],
+              image: imgSrcList[index],
               fit: BoxFit.cover,
             ),
           ),
@@ -30,7 +28,7 @@ class LUSwiper extends StatelessWidget {
       },
       indicatorLayout: PageIndicatorLayout.SCALE,
       autoplay: false,
-      itemCount: images.length,
+      itemCount: imgSrcList.length,
       outer: true,
       pagination: SwiperPagination(
           margin: EdgeInsets.only(top: 16),

--- a/lib/components/swiper.dart
+++ b/lib/components/swiper.dart
@@ -1,3 +1,5 @@
+import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/utils/images.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_page_indicator/flutter_page_indicator.dart';
 import 'package:flutter_swiper/flutter_swiper.dart';
@@ -13,15 +15,22 @@ class LUSwiper extends StatelessWidget {
   Widget build(BuildContext context) {
     return Swiper(
       itemBuilder: (BuildContext context, int index) {
-        return Image.network(
-          images[index],
-          fit: BoxFit.fill,
+        return FadeInImage.assetNetwork(
+          placeholder: Images.horizontalPlaceholder,
+          image: images[index],
+          fit: BoxFit.cover,
         );
       },
       indicatorLayout: PageIndicatorLayout.SCALE,
       autoplay: false,
       itemCount: images.length,
-      pagination: SwiperPagination(),
+      outer: true,
+      pagination: SwiperPagination(
+          margin: EdgeInsets.only(top: 16),
+          builder: DotSwiperPaginationBuilder(
+              space: 8.0,
+              color: LUTheme.of(context).unselectedWidgetColor,
+              activeColor: LUTheme.of(context).primaryColor)),
     );
   }
 }

--- a/lib/components/swiper.dart
+++ b/lib/components/swiper.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_page_indicator/flutter_page_indicator.dart';
 import 'package:flutter_swiper/flutter_swiper.dart';
 
+/// A custom [Swiper] that allows the user to slide through images.
 class LUSwiper extends StatelessWidget {
   final List<String> imgSrcList;
 

--- a/lib/configs/routes.dart
+++ b/lib/configs/routes.dart
@@ -5,6 +5,7 @@ import 'package:dr_app/screens/explore_screen.dart';
 import 'package:dr_app/screens/home_screen.dart';
 import 'package:dr_app/screens/more_screen.dart';
 import 'package:dr_app/screens/outlet_detail_screen.dart';
+import 'package:dr_app/screens/product_screen.dart';
 import 'package:dr_app/screens/profile_screen.dart';
 import 'package:dr_app/screens/scanner_screen.dart';
 import 'package:flutter/widgets.dart';
@@ -19,7 +20,8 @@ final Map<String, WidgetBuilder> routes = {
   ScannerScreen.id: (context) => ScannerScreen(),
   OutletDetailScreen.id: (context) => OutletDetailScreen(),
   CategoryDetailScreen.id: (context) => CategoryDetailScreen(),
-  CuisineScreen.id: (context) => CuisineScreen()
+  CuisineScreen.id: (context) => CuisineScreen(),
+  ProductScreen.id: (context) => ProductScreen()
 };
 
 final Set<String> fullScreenRoutes = {ScannerScreen.id};

--- a/lib/configs/theme.dart
+++ b/lib/configs/theme.dart
@@ -41,12 +41,21 @@ class LUTheme {
             )),
             elevation: 4.0),
         textTheme: baseTheme.textTheme.copyWith(
+          // fontSize: 32
+          headline1: Styles.productTitle,
+          // fontSize: 36
           headline2: Styles.sloganTitleEmphasis,
+          // fontSize: 28
           headline3: Styles.sloganTitle,
+          // fontSize: 18
           button: Styles.button,
+          // fontSize: 24
           headline5: Styles.cardTitle,
+          // fontSize: 22
           headline6: Styles.cardSubtitle,
+          // fontSize: 18
           bodyText1: Styles.cardPriceRange,
+          // fontSize: 16
           bodyText2: Styles.categoryCardTitle,
         ));
   }

--- a/lib/data/dummy/dummy_data.dart
+++ b/lib/data/dummy/dummy_data.dart
@@ -41,3 +41,9 @@ const dummyFeaturedOutlets = [
   FeaturedOutlet(
       'Bar Soba', 'Asian Fusion', 4, '\$\$', 'https://picsum.photos/1004')
 ];
+
+const List<String> dummySwiperImages = [
+  'https://picsum.photos/200/400',
+  'https://picsum.photos/200/500',
+  'https://picsum.photos/200/200'
+];

--- a/lib/screens/cuisine_screen.dart
+++ b/lib/screens/cuisine_screen.dart
@@ -109,7 +109,7 @@ class _CuisineScreenState extends State<CuisineScreen> {
                 ),
                 Text(
                   'Glasgow',
-                  style: Styles.location,
+                  style: Styles.locationText,
                 ),
                 SizedBox(
                   width: 8,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -193,13 +193,13 @@ class _HomeContent extends StatelessWidget {
               title: "Chef's choice - Glasgow",
               child: LUCarousel(
                   height: _HomeStyles.featuredSectionHeight,
-                  padding: Styles.carouselPadding,
+                  padding: Styles.sectionContentPadding,
                   items: _getFeaturedCards(context))),
           LUSection(
               title: 'Cuisines',
               child: LUCarousel(
                   height: Styles.categoryCarouselHeight,
-                  padding: Styles.carouselPadding,
+                  padding: Styles.sectionContentPadding,
                   items: _getCategoryCards(context))),
           LUSection(
             title: 'Nearby Restaurants',

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:dr_app/components/cards/featured_card.dart';
 import 'package:dr_app/components/cards/outlet_card.dart';
 import 'package:dr_app/components/carousel.dart';
 import 'package:dr_app/components/list.dart';
+import 'package:dr_app/components/section.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/data/dummy/dummy_data.dart';
@@ -13,21 +14,20 @@ import 'package:dr_app/screens/product_screen.dart';
 import 'package:dr_app/screens/scanner_screen.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
-import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_vector_icons/flutter_vector_icons.dart';
 
 import 'cuisine_screen.dart';
 
 abstract class _HomeStyles {
-  static const topBarPadding =
-      const EdgeInsets.only(left: 16, right: 16, top: 8);
   static const double headerHeight = 200;
   static const backgroundBorderRadius = const BorderRadius.only(
       topLeft: Radius.circular(40), topRight: Radius.circular(40));
   static const double featuredSectionHeight = 280;
   static const double cuisineSectionHeight = 160;
   static const sectionSpacing = const EdgeInsets.only(top: 16.0);
+  static const carouselPadding =
+      const EdgeInsets.only(left: 16, right: 16, bottom: 8);
 }
 
 /// The Home screen of the App. This screen has two main states: unchecked
@@ -192,84 +192,28 @@ class _HomeContent extends StatelessWidget {
                 title: "Find a Restaurant",
                 onPressed: () {}),
           ),
-          _HorizontalHomeSection(
+          LUSection(
               title: "Chef's choice - Glasgow",
-              height: _HomeStyles.featuredSectionHeight,
-              items: _getFeaturedCards(context)),
-          _HorizontalHomeSection(
-            title: 'Cuisines',
-            height: _HomeStyles.cuisineSectionHeight,
-            items: _getCategoryCards(context),
-          ),
-          _VerticalHomeSection(
-              title: 'Nearby Restaurants', items: _getOutletCards())
-        ]));
-  }
-}
-
-class _HorizontalHomeSection extends StatelessWidget {
-  final double height;
-  final String title;
-  final List<Widget> items;
-
-  const _HorizontalHomeSection({Key key, this.height, this.title, this.items})
-      : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: _HomeStyles.sectionSpacing,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.only(left: 18),
-            child: Text(
-              title,
-              style: Styles.section,
-            ),
-          ),
-          LUCarousel(
-              height: height,
-              padding: EdgeInsets.only(left: 16, right: 16, top: 8, bottom: 8),
-              items: items)
-        ],
-      ),
-    );
-  }
-}
-
-class _VerticalHomeSection extends StatelessWidget {
-  final String title;
-  final List<Widget> items;
-
-  const _VerticalHomeSection({Key key, this.title, this.items})
-      : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: _HomeStyles.sectionSpacing,
-      child: Column(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.only(left: 18, bottom: 12),
-              child: Text(
-                title,
-                style: Styles.section,
-              ),
-            ),
-            LUList(
+              margin: _HomeStyles.sectionSpacing,
+              child: LUCarousel(
+                  height: _HomeStyles.featuredSectionHeight,
+                  padding: _HomeStyles.carouselPadding,
+                  items: _getFeaturedCards(context))),
+          LUSection(
+              title: 'Cuisines',
+              margin: _HomeStyles.sectionSpacing,
+              child: LUCarousel(
+                  height: _HomeStyles.cuisineSectionHeight,
+                  padding: _HomeStyles.carouselPadding,
+                  items: _getCategoryCards(context))),
+          LUSection(
+            title: 'Nearby Restaurants',
+            child: LUList(
               nested: true,
               space: 10,
-              items: items,
-            )
-          ]),
-    );
+              items: _getOutletCards(),
+            ),
+          ),
+        ]));
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,6 +9,7 @@ import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/data/dummy/dummy_data.dart';
 import 'package:dr_app/data/models/screen_arguments.dart';
+import 'package:dr_app/screens/product_screen.dart';
 import 'package:dr_app/screens/scanner_screen.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
@@ -149,12 +150,16 @@ class _HomeContent extends StatelessWidget {
           ))
       .toList();
 
-  List<Widget> _getFeaturedCards() => dummyFeaturedOutlets
+  List<Widget> _getFeaturedCards(context) => dummyFeaturedOutlets
       .map((outlet) => LUFeaturedCard(
             imageSrc: outlet.imgSrc,
             title: outlet.name,
             subtitle: outlet.category,
-            onPressed: () {},
+            onPressed: () {
+              Navigator.of(context).pushNamed(ProductScreen.id,
+                  arguments: ScreenArguments(
+                      title: outlet.name, coverImgSrc: outlet.imgSrc));
+            },
             rating: outlet.rating,
             priceRange: outlet.priceRange,
           ))
@@ -190,7 +195,7 @@ class _HomeContent extends StatelessWidget {
           _HorizontalHomeSection(
               title: "Chef's choice - Glasgow",
               height: _HomeStyles.featuredSectionHeight,
-              items: _getFeaturedCards()),
+              items: _getFeaturedCards(context)),
           _HorizontalHomeSection(
             title: 'Cuisines',
             height: _HomeStyles.cuisineSectionHeight,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -14,6 +14,7 @@ import 'package:dr_app/screens/product_screen.dart';
 import 'package:dr_app/screens/scanner_screen.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
+import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_vector_icons/flutter_vector_icons.dart';
 
@@ -24,10 +25,6 @@ abstract class _HomeStyles {
   static const backgroundBorderRadius = const BorderRadius.only(
       topLeft: Radius.circular(40), topRight: Radius.circular(40));
   static const double featuredSectionHeight = 280;
-  static const double cuisineSectionHeight = 160;
-  static const sectionSpacing = const EdgeInsets.only(top: 16.0);
-  static const carouselPadding =
-      const EdgeInsets.only(left: 16, right: 16, bottom: 8);
 }
 
 /// The Home screen of the App. This screen has two main states: unchecked
@@ -194,17 +191,15 @@ class _HomeContent extends StatelessWidget {
           ),
           LUSection(
               title: "Chef's choice - Glasgow",
-              margin: _HomeStyles.sectionSpacing,
               child: LUCarousel(
                   height: _HomeStyles.featuredSectionHeight,
-                  padding: _HomeStyles.carouselPadding,
+                  padding: Styles.carouselPadding,
                   items: _getFeaturedCards(context))),
           LUSection(
               title: 'Cuisines',
-              margin: _HomeStyles.sectionSpacing,
               child: LUCarousel(
-                  height: _HomeStyles.cuisineSectionHeight,
-                  padding: _HomeStyles.carouselPadding,
+                  height: Styles.categoryCarouselHeight,
+                  padding: Styles.carouselPadding,
                   items: _getCategoryCards(context))),
           LUSection(
             title: 'Nearby Restaurants',

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -2,6 +2,7 @@ import 'package:dr_app/components/cards/category_card.dart';
 import 'package:dr_app/components/carousel.dart';
 import 'package:dr_app/components/section.dart';
 import 'package:dr_app/components/top_bar.dart';
+import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/data/dummy/dummy_data.dart';
 import 'package:dr_app/data/models/screen_arguments.dart';
 import 'package:dr_app/utils/images.dart';
@@ -10,6 +11,7 @@ import 'package:flutter/material.dart';
 
 class ProductScreen extends StatefulWidget {
   static const id = 'product_screen';
+
   @override
   _ProductScreenState createState() => _ProductScreenState();
 }
@@ -57,16 +59,33 @@ class _ProductScreenState extends State<ProductScreen> {
       );
 
   Widget _buildContent(ScreenArguments args) => Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Text('Chicken Noodles'),
-          Text('£ 8.50 each'),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: <Widget>[
-              Text('Counter'),
-              Text('£ 8.50'),
-            ],
+          Padding(
+            padding: Styles.sectionContentPadding.copyWith(top: 24, bottom: 32),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Chicken Noodles',
+                  style: LUTheme.of(context).textTheme.headline1,
+                  textAlign: TextAlign.left,
+                ),
+                Text('£ 8.50 each', style: Styles.productSubtitle),
+                SizedBox(
+                  height: 24,
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    Text('Counter'),
+                    Text('£ 8.50'),
+                  ],
+                ),
+              ],
+            ),
           ),
           LUSection(
             title: 'Dish Description',

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dr_app/components/buttons/solid_button.dart';
 import 'package:dr_app/components/cards/category_card.dart';
 import 'package:dr_app/components/carousel.dart';
+import 'package:dr_app/components/counter.dart';
 import 'package:dr_app/components/section.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
@@ -95,8 +96,14 @@ class _ProductScreenState extends State<ProductScreen> {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: <Widget>[
-                    Text('Counter'),
-                    Text('£ 8.50'),
+                    LUCounter(),
+                    Text(
+                      '£ 8.50',
+                      style: LUTheme.of(context)
+                          .textTheme
+                          .headline1
+                          .copyWith(fontWeight: FontWeight.w400),
+                    ),
                   ],
                 ),
               ],

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -33,26 +33,29 @@ class _ProductScreenState extends State<ProductScreen> {
   @override
   Widget build(BuildContext context) {
     final ScreenArguments args = ModalRoute.of(context).settings.arguments;
-    return Stack(
-      children: <Widget>[
-        ListView(
-          padding: EdgeInsets.zero,
-          children: <Widget>[
-            _buildHeader(args),
-            _buildContent(args),
-          ],
-        ),
-        Positioned(
-          left: 0,
-          right: 0,
-          bottom: 40.0,
-          child: LUSolidButton(
-            title: 'ADD TO BASKET',
-            margin: EdgeInsets.symmetric(horizontal: 16),
-            onPressed: () {},
+    return Container(
+      color: LUTheme.of(context).backgroundColor,
+      child: Stack(
+        children: <Widget>[
+          ListView(
+            padding: EdgeInsets.zero,
+            children: <Widget>[
+              _buildHeader(args),
+              _buildContent(args),
+            ],
           ),
-        )
-      ],
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 40.0,
+            child: LUSolidButton(
+              title: 'ADD TO BASKET',
+              margin: EdgeInsets.symmetric(horizontal: 16),
+              onPressed: () {},
+            ),
+          )
+        ],
+      ),
     );
   }
 
@@ -68,68 +71,64 @@ class _ProductScreenState extends State<ProductScreen> {
         ),
       );
 
-  Widget _buildContent(ScreenArguments args) => Container(
-        color: LUTheme.of(context).backgroundColor,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Padding(
-              padding:
-                  Styles.sectionContentPadding.copyWith(top: 24, bottom: 32),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    'Chicken Noodles',
-                    style: LUTheme.of(context).textTheme.headline1,
-                    textAlign: TextAlign.left,
-                  ),
-                  SizedBox(
-                    height: 2,
-                  ),
-                  Text('£ 8.50 each', style: Styles.productSubtitle),
-                  SizedBox(
-                    height: 24,
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: <Widget>[
-                      LUCounter(
-                        onUpdate: (amount) {
-                          print(amount);
-                        },
-                      ),
-                      Text(
-                        '£ 8.50',
-                        style: LUTheme.of(context)
-                            .textTheme
-                            .headline1
-                            .copyWith(fontWeight: FontWeight.w400),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-            LUSection(
-              title: 'Dish Description',
-              child: Padding(
-                padding: Styles.sectionContentPadding,
-                child: Text(
-                  'ASIAN GREENS WITH FRIED TOFU IN A CHILLI, GARLIC, SOY & BASIL SAUCE, SERVED WITH EGG NOODLES CASHEW NUTS & FRESH CHILLI.',
-                  style: Styles.descriptionText,
+  Widget _buildContent(ScreenArguments args) => Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: Styles.sectionContentPadding.copyWith(top: 24, bottom: 32),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Chicken Noodles',
+                  style: LUTheme.of(context).textTheme.headline1,
+                  textAlign: TextAlign.left,
                 ),
+                SizedBox(
+                  height: 2,
+                ),
+                Text('£ 8.50 each', style: Styles.productSubtitle),
+                SizedBox(
+                  height: 24,
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    LUCounter(
+                      onUpdate: (amount) {
+                        print(amount);
+                      },
+                    ),
+                    Text(
+                      '£ 8.50',
+                      style: LUTheme.of(context)
+                          .textTheme
+                          .headline1
+                          .copyWith(fontWeight: FontWeight.w400),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          LUSection(
+            title: 'Dish Description',
+            child: Padding(
+              padding: Styles.sectionContentPadding,
+              child: Text(
+                'ASIAN GREENS WITH FRIED TOFU IN A CHILLI, GARLIC, SOY & BASIL SAUCE, SERVED WITH EGG NOODLES CASHEW NUTS & FRESH CHILLI.',
+                style: Styles.descriptionText,
               ),
             ),
-            LUSection(
-                title: 'Ingredients',
-                child: LUCarousel(
-                    height: Styles.categoryCarouselHeight,
-                    padding: Styles.sectionContentPadding,
-                    items: _getCategoryCards(context))),
-          ],
-        ),
+          ),
+          LUSection(
+              title: 'Ingredients',
+              child: LUCarousel(
+                  height: Styles.categoryCarouselHeight,
+                  padding: Styles.sectionContentPadding,
+                  items: _getCategoryCards(context))),
+        ],
       );
 }

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -1,12 +1,12 @@
+import 'package:dr_app/components/cards/category_card.dart';
+import 'package:dr_app/components/carousel.dart';
 import 'package:dr_app/components/section.dart';
 import 'package:dr_app/components/top_bar.dart';
+import 'package:dr_app/data/dummy/dummy_data.dart';
 import 'package:dr_app/data/models/screen_arguments.dart';
 import 'package:dr_app/utils/images.dart';
+import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
-
-class _ProductScreenStyles {
-  static const sectionPadding = const EdgeInsets.symmetric(horizontal: 16.0);
-}
 
 class ProductScreen extends StatefulWidget {
   static const id = 'product_screen';
@@ -18,6 +18,13 @@ class _ProductScreenState extends State<ProductScreen> {
   void _onBackButtonPressed() {
     Navigator.of(context).pop();
   }
+
+  List<Widget> _getCategoryCards(context) => dummyCuisines
+      .map((cuisine) => LUCategoryCard(
+            title: cuisine.name,
+            imageSrc: cuisine.imgSrc,
+          ))
+      .toList();
 
   @override
   Widget build(BuildContext context) {
@@ -49,26 +56,29 @@ class _ProductScreenState extends State<ProductScreen> {
         ),
       );
 
-  Widget _buildContent(ScreenArguments args) => Padding(
-        padding: _ProductScreenStyles.sectionPadding,
-        child: Column(
-          children: <Widget>[
-            Text('Chicken Noodles'),
-            Text('£ 8.50 each'),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                Text('Counter'),
-                Text('£ 8.50'),
-              ],
-            ),
-            LUSection(
-              title: 'Dish Description',
-              child: Text(
-                  'ASIAN GREENS WITH FRIED TOFU IN A CHILLI, GARLIC, SOY & BASIL SAUCE, SERVED WITH EGG NOODLES CASHEW NUTS & FRESH CHILLI.'),
-            )
-          ],
-        ),
+  Widget _buildContent(ScreenArguments args) => Column(
+        children: <Widget>[
+          Text('Chicken Noodles'),
+          Text('£ 8.50 each'),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              Text('Counter'),
+              Text('£ 8.50'),
+            ],
+          ),
+          LUSection(
+            title: 'Dish Description',
+            child: Text(
+                'ASIAN GREENS WITH FRIED TOFU IN A CHILLI, GARLIC, SOY & BASIL SAUCE, SERVED WITH EGG NOODLES CASHEW NUTS & FRESH CHILLI.'),
+          ),
+          LUSection(
+              title: 'Ingredients',
+              child: LUCarousel(
+                  height: Styles.categoryCarouselHeight,
+                  padding: Styles.carouselPadding,
+                  items: _getCategoryCards(context))),
+        ],
       );
 }

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -1,0 +1,21 @@
+import 'package:dr_app/data/models/screen_arguments.dart';
+import 'package:flutter/material.dart';
+
+class ProductScreen extends StatefulWidget {
+  static const id = 'product_screen';
+  @override
+  _ProductScreenState createState() => _ProductScreenState();
+}
+
+class _ProductScreenState extends State<ProductScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final ScreenArguments args = ModalRoute.of(context).settings.arguments;
+    return Container(
+      color: Colors.blue,
+      child: Center(
+        child: Text(args.title),
+      ),
+    );
+  }
+}

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -70,14 +70,19 @@ class _ProductScreenState extends State<ProductScreen> {
           ),
           LUSection(
             title: 'Dish Description',
-            child: Text(
-                'ASIAN GREENS WITH FRIED TOFU IN A CHILLI, GARLIC, SOY & BASIL SAUCE, SERVED WITH EGG NOODLES CASHEW NUTS & FRESH CHILLI.'),
+            child: Padding(
+              padding: Styles.sectionContentPadding,
+              child: Text(
+                'ASIAN GREENS WITH FRIED TOFU IN A CHILLI, GARLIC, SOY & BASIL SAUCE, SERVED WITH EGG NOODLES CASHEW NUTS & FRESH CHILLI.',
+                style: Styles.descriptionText,
+              ),
+            ),
           ),
           LUSection(
               title: 'Ingredients',
               child: LUCarousel(
                   height: Styles.categoryCarouselHeight,
-                  padding: Styles.carouselPadding,
+                  padding: Styles.sectionContentPadding,
                   items: _getCategoryCards(context))),
         ],
       );

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -60,14 +60,7 @@ class _ProductScreenState extends State<ProductScreen> {
         height: 400,
         child: Stack(
           children: <Widget>[
-//            Positioned.fill(
-//              child: FadeInImage.assetNetwork(
-//                placeholder: Images.horizontalPlaceholder,
-//                image: args.coverImgSrc,
-//                fit: BoxFit.cover,
-//              ),
-//            ),
-            LUSwiper(),
+            LUSwiper(imgSrcList: dummySwiperImages),
             LUTopBar(
               onNavigationButtonPressed: _onBackButtonPressed,
             ),
@@ -75,64 +68,68 @@ class _ProductScreenState extends State<ProductScreen> {
         ),
       );
 
-  Widget _buildContent(ScreenArguments args) => Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Padding(
-            padding: Styles.sectionContentPadding.copyWith(top: 24, bottom: 32),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  'Chicken Noodles',
-                  style: LUTheme.of(context).textTheme.headline1,
-                  textAlign: TextAlign.left,
-                ),
-                SizedBox(
-                  height: 2,
-                ),
-                Text('£ 8.50 each', style: Styles.productSubtitle),
-                SizedBox(
-                  height: 24,
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    LUCounter(
-                      onUpdate: (amount) {
-                        print(amount);
-                      },
-                    ),
-                    Text(
-                      '£ 8.50',
-                      style: LUTheme.of(context)
-                          .textTheme
-                          .headline1
-                          .copyWith(fontWeight: FontWeight.w400),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-          LUSection(
-            title: 'Dish Description',
-            child: Padding(
-              padding: Styles.sectionContentPadding,
-              child: Text(
-                'ASIAN GREENS WITH FRIED TOFU IN A CHILLI, GARLIC, SOY & BASIL SAUCE, SERVED WITH EGG NOODLES CASHEW NUTS & FRESH CHILLI.',
-                style: Styles.descriptionText,
+  Widget _buildContent(ScreenArguments args) => Container(
+        color: LUTheme.of(context).backgroundColor,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Padding(
+              padding:
+                  Styles.sectionContentPadding.copyWith(top: 24, bottom: 32),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    'Chicken Noodles',
+                    style: LUTheme.of(context).textTheme.headline1,
+                    textAlign: TextAlign.left,
+                  ),
+                  SizedBox(
+                    height: 2,
+                  ),
+                  Text('£ 8.50 each', style: Styles.productSubtitle),
+                  SizedBox(
+                    height: 24,
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: <Widget>[
+                      LUCounter(
+                        onUpdate: (amount) {
+                          print(amount);
+                        },
+                      ),
+                      Text(
+                        '£ 8.50',
+                        style: LUTheme.of(context)
+                            .textTheme
+                            .headline1
+                            .copyWith(fontWeight: FontWeight.w400),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ),
-          ),
-          LUSection(
-              title: 'Ingredients',
-              child: LUCarousel(
-                  height: Styles.categoryCarouselHeight,
-                  padding: Styles.sectionContentPadding,
-                  items: _getCategoryCards(context))),
-        ],
+            LUSection(
+              title: 'Dish Description',
+              child: Padding(
+                padding: Styles.sectionContentPadding,
+                child: Text(
+                  'ASIAN GREENS WITH FRIED TOFU IN A CHILLI, GARLIC, SOY & BASIL SAUCE, SERVED WITH EGG NOODLES CASHEW NUTS & FRESH CHILLI.',
+                  style: Styles.descriptionText,
+                ),
+              ),
+            ),
+            LUSection(
+                title: 'Ingredients',
+                child: LUCarousel(
+                    height: Styles.categoryCarouselHeight,
+                    padding: Styles.sectionContentPadding,
+                    items: _getCategoryCards(context))),
+          ],
+        ),
       );
 }

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -11,6 +11,9 @@ import 'package:dr_app/data/models/screen_arguments.dart';
 import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 
+/// The Product Screen displays information about a given product.
+/// The user can choose the desired quantity and add the product
+/// to the cart.
 class ProductScreen extends StatefulWidget {
   static const id = 'product_screen';
 

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -88,6 +88,9 @@ class _ProductScreenState extends State<ProductScreen> {
                   style: LUTheme.of(context).textTheme.headline1,
                   textAlign: TextAlign.left,
                 ),
+                SizedBox(
+                  height: 2,
+                ),
                 Text('£ 8.50 each', style: Styles.productSubtitle),
                 SizedBox(
                   height: 24,

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -96,7 +96,11 @@ class _ProductScreenState extends State<ProductScreen> {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: <Widget>[
-                    LUCounter(),
+                    LUCounter(
+                      onUpdate: (amount) {
+                        print(amount);
+                      },
+                    ),
                     Text(
                       '£ 8.50',
                       style: LUTheme.of(context)

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -3,11 +3,11 @@ import 'package:dr_app/components/cards/category_card.dart';
 import 'package:dr_app/components/carousel.dart';
 import 'package:dr_app/components/counter.dart';
 import 'package:dr_app/components/section.dart';
+import 'package:dr_app/components/swiper.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/data/dummy/dummy_data.dart';
 import 'package:dr_app/data/models/screen_arguments.dart';
-import 'package:dr_app/utils/images.dart';
 import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 
@@ -60,13 +60,14 @@ class _ProductScreenState extends State<ProductScreen> {
         height: 400,
         child: Stack(
           children: <Widget>[
-            Positioned.fill(
-              child: FadeInImage.assetNetwork(
-                placeholder: Images.horizontalPlaceholder,
-                image: args.coverImgSrc,
-                fit: BoxFit.cover,
-              ),
-            ),
+//            Positioned.fill(
+//              child: FadeInImage.assetNetwork(
+//                placeholder: Images.horizontalPlaceholder,
+//                image: args.coverImgSrc,
+//                fit: BoxFit.cover,
+//              ),
+//            ),
+            LUSwiper(),
             LUTopBar(
               onNavigationButtonPressed: _onBackButtonPressed,
             ),

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dr_app/components/buttons/solid_button.dart';
 import 'package:dr_app/components/cards/category_card.dart';
 import 'package:dr_app/components/carousel.dart';
 import 'package:dr_app/components/section.dart';
@@ -31,11 +32,25 @@ class _ProductScreenState extends State<ProductScreen> {
   @override
   Widget build(BuildContext context) {
     final ScreenArguments args = ModalRoute.of(context).settings.arguments;
-    return ListView(
-      padding: EdgeInsets.zero,
+    return Stack(
       children: <Widget>[
-        _buildHeader(args),
-        _buildContent(args),
+        ListView(
+          padding: EdgeInsets.zero,
+          children: <Widget>[
+            _buildHeader(args),
+            _buildContent(args),
+          ],
+        ),
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 40.0,
+          child: LUSolidButton(
+            title: 'ADD TO BASKET',
+            margin: EdgeInsets.symmetric(horizontal: 16),
+            onPressed: () {},
+          ),
+        )
       ],
     );
   }

--- a/lib/screens/product_screen.dart
+++ b/lib/screens/product_screen.dart
@@ -1,5 +1,12 @@
+import 'package:dr_app/components/section.dart';
+import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/data/models/screen_arguments.dart';
+import 'package:dr_app/utils/images.dart';
 import 'package:flutter/material.dart';
+
+class _ProductScreenStyles {
+  static const sectionPadding = const EdgeInsets.symmetric(horizontal: 16.0);
+}
 
 class ProductScreen extends StatefulWidget {
   static const id = 'product_screen';
@@ -8,14 +15,60 @@ class ProductScreen extends StatefulWidget {
 }
 
 class _ProductScreenState extends State<ProductScreen> {
+  void _onBackButtonPressed() {
+    Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     final ScreenArguments args = ModalRoute.of(context).settings.arguments;
-    return Container(
-      color: Colors.blue,
-      child: Center(
-        child: Text(args.title),
-      ),
+    return ListView(
+      padding: EdgeInsets.zero,
+      children: <Widget>[
+        _buildHeader(args),
+        _buildContent(args),
+      ],
     );
   }
+
+  Widget _buildHeader(ScreenArguments args) => Container(
+        height: 400,
+        child: Stack(
+          children: <Widget>[
+            Positioned.fill(
+              child: FadeInImage.assetNetwork(
+                placeholder: Images.horizontalPlaceholder,
+                image: args.coverImgSrc,
+                fit: BoxFit.cover,
+              ),
+            ),
+            LUTopBar(
+              onNavigationButtonPressed: _onBackButtonPressed,
+            ),
+          ],
+        ),
+      );
+
+  Widget _buildContent(ScreenArguments args) => Padding(
+        padding: _ProductScreenStyles.sectionPadding,
+        child: Column(
+          children: <Widget>[
+            Text('Chicken Noodles'),
+            Text('£ 8.50 each'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                Text('Counter'),
+                Text('£ 8.50'),
+              ],
+            ),
+            LUSection(
+              title: 'Dish Description',
+              child: Text(
+                  'ASIAN GREENS WITH FRIED TOFU IN A CHILLI, GARLIC, SOY & BASIL SAUCE, SERVED WITH EGG NOODLES CASHEW NUTS & FRESH CHILLI.'),
+            )
+          ],
+        ),
+      );
 }

--- a/lib/utils/colors.dart
+++ b/lib/utils/colors.dart
@@ -7,6 +7,6 @@ abstract class LUColors {
   static const smoothWhite = Color(0xFFFAFAFA);
   static const darkBlue = Color(0xFF2D3142);
   static const navyBlue = Color(0xFF4F5D75);
-  static const gray = Color(0xCC969696);
+  static const gray = Color(0xFF969696);
   static const smoothGray = Color(0xFFE3E3E3);
 }

--- a/lib/utils/styles.dart
+++ b/lib/utils/styles.dart
@@ -45,6 +45,9 @@ abstract class Styles {
       color: LUColors.darkBlue, fontSize: 17, fontWeight: FontWeight.w200);
   static const descriptionText =
       TextStyle(color: LUColors.darkBlue, fontSize: 14);
+  static const productTitle = TextStyle(
+      color: LUColors.darkBlue, fontSize: 32, fontWeight: FontWeight.bold);
+  static const productSubtitle = TextStyle(color: LUColors.gray, fontSize: 17);
 
   /// Container Styles
   static const double roundContainerHeight = 240;

--- a/lib/utils/styles.dart
+++ b/lib/utils/styles.dart
@@ -39,10 +39,12 @@ abstract class Styles {
       TextStyle(fontSize: 18, color: Colors.white, fontWeight: FontWeight.w600);
 
   /// Text Styles
-  static const section = TextStyle(
+  static const sectionText = TextStyle(
       color: LUColors.darkBlue, fontSize: 17, fontWeight: FontWeight.w600);
-  static const location = TextStyle(
+  static const locationText = TextStyle(
       color: LUColors.darkBlue, fontSize: 17, fontWeight: FontWeight.w200);
+  static const descriptionText =
+      TextStyle(color: LUColors.darkBlue, fontSize: 14);
 
   /// Container Styles
   static const double roundContainerHeight = 240;
@@ -50,7 +52,7 @@ abstract class Styles {
       topLeft: Radius.circular(40), topRight: Radius.circular(40));
 
   /// List Styles
-  static const carouselPadding =
+  static const sectionContentPadding =
       const EdgeInsets.only(left: 16, right: 16, bottom: 8);
   static const double categoryCarouselHeight = 160;
 }

--- a/lib/utils/styles.dart
+++ b/lib/utils/styles.dart
@@ -48,4 +48,9 @@ abstract class Styles {
   static const double roundContainerHeight = 240;
   static const roundContainerRadius = const BorderRadius.only(
       topLeft: Radius.circular(40), topRight: Radius.circular(40));
+
+  /// List Styles
+  static const carouselPadding =
+      const EdgeInsets.only(left: 16, right: 16, bottom: 8);
+  static const double categoryCarouselHeight = 160;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,6 +69,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_page_indicator:
+    dependency: "direct main"
+    description:
+      name: flutter_page_indicator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.3"
+  flutter_swiper:
+    dependency: "direct main"
+    description:
+      name: flutter_swiper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -193,6 +207,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.15"
+  transformer_page_view:
+    dependency: transitive
+    description:
+      name: transformer_page_view
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.6"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   # Custom UI Components
   slider_button: ^0.5.0
   smooth_star_rating: 1.1.1
+  flutter_swiper: ^1.1.6
+  flutter_page_indicator: ^0.0.3
 
   # Custom Capabilities
   qr_code_scanner:


### PR DESCRIPTION
# Product Screen

**Result**
<img width="470" alt="Screenshot 2020-07-26 at 16 38 51" src="https://user-images.githubusercontent.com/11461969/88483238-7e3ca300-cf5e-11ea-9a92-7e20eb442d09.png">

**Highlights**
- Create the `ProductScreen` and register its route
- Create the `LUCounter` button
- Extract `Carousel` and `Section` 
- Create the `LUSwiper` custom widget
- Add [flutter_swiper](https://github.com/best-flutter/flutter_swiper) and [flutter_page_indicator](https://github.com/best-flutter/flutter_page_indicator) dependencies

**Notes**
- Please ignore the bottom FAB -- it will be removed later
- The original wave clip design was dropped to speed up development. Revisit this later.
- Investigate the initial `PageIndicator` state -- it seems glitched. 