### PR TITLE
#46 Card Payment Screen

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.dr_app"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/components/bottom_sliver.dart
+++ b/lib/components/bottom_sliver.dart
@@ -12,7 +12,7 @@ enum BottomSliverButton { SOLID, SLIDER }
 /// of type [LUSliderButton] or [LUSolidButton].
 class LUBottomSliver extends StatelessWidget {
   final double subtotal;
-  final String tip;
+  final double tip;
   final String buttonTitle;
   final VoidCallback onButtonPressed;
   final BottomSliverButton buttonType;
@@ -48,6 +48,7 @@ class LUBottomSliver extends StatelessWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: <Widget>[
+              tip != null ? buildTip() : Container(),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: <Widget>[
@@ -77,4 +78,19 @@ class LUBottomSliver extends StatelessWidget {
               title: buttonTitle,
               onPressed: onButtonPressed,
             ));
+
+  Widget buildTip() {
+    final double tipIncludedDisplay = tip * 100;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: <Widget>[
+        Text(
+          'Tip Included',
+          style: Styles.tipIncludedText,
+        ),
+        Text("$tipIncludedDisplay%", style: Styles.tipIncludedText)
+      ],
+    );
+  }
 }

--- a/lib/components/compact_header.dart
+++ b/lib/components/compact_header.dart
@@ -1,4 +1,5 @@
 import 'package:dr_app/components/top_bar.dart';
+import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/utils/images.dart';
 import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
@@ -27,6 +28,7 @@ class LUCompactHeader extends StatelessWidget {
           ),
           LUTopBar(
             icon: icon,
+            tint: LUTheme.of(context).primaryColor,
             onNavigationButtonPressed: onTopButtonPressed,
           ),
         ],

--- a/lib/components/credit_card_stack.dart
+++ b/lib/components/credit_card_stack.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+/// A collection of credit cards stacked on the top of each other.
+class LUCreditCardStack extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}

--- a/lib/components/tip_toolbar.dart
+++ b/lib/components/tip_toolbar.dart
@@ -1,47 +1,81 @@
 import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/data/models/tip.dart';
 import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 
 /// A bar containing buttons to select the desired tip value.
-class LUTipToolbar extends StatelessWidget {
-  final List<String> tipOptions;
+class LUTipToolbar extends StatefulWidget {
+  final List<Tip> tipOptions;
   final EdgeInsetsGeometry margin;
+  final ValueChanged<Tip> onPressed;
 
-  const LUTipToolbar({Key key, this.tipOptions, this.margin}) : super(key: key);
+  const LUTipToolbar({Key key, this.tipOptions, this.margin, this.onPressed})
+      : super(key: key);
+
+  @override
+  _LUTipToolbarState createState() => _LUTipToolbarState();
+}
+
+class _LUTipToolbarState extends State<LUTipToolbar> {
+  int selectedIndex;
 
   @override
   Widget build(BuildContext context) {
-    final List indexList =
-        Iterable<int>.generate(tipOptions.length + tipOptions.length - 1)
-            .toList();
+    final List indexList = Iterable<int>.generate(
+            widget.tipOptions.length + widget.tipOptions.length - 1)
+        .toList();
 
     return Padding(
-      padding: margin ?? EdgeInsets.zero,
+      padding: widget.margin ?? EdgeInsets.zero,
       child: Container(
         height: 56.0,
         decoration: BoxDecoration(
             color: LUTheme.of(context).unselectedWidgetColor,
             borderRadius: BorderRadius.circular(LUTheme.buttonBorderRadius)),
-        child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: indexList.map((index) {
-              if (index % 2 != 0) {
-                return VerticalDivider(
-                  width: 4,
-                  indent: 4,
-                  endIndent: 4,
-                  color: const Color(0X443C3C43),
+        child: ClipRRect(
+          borderRadius:
+              BorderRadius.all(Radius.circular(LUTheme.buttonBorderRadius)),
+          child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: indexList.map((index) {
+                if (index % 2 != 0) {
+                  return VerticalDivider(
+                    width: 4,
+                    indent: 4,
+                    endIndent: 4,
+                    color: const Color(0X443C3C43),
+                  );
+                }
+
+                final currentIndex = (index ~/ 2) % widget.tipOptions.length;
+
+                return Expanded(
+                  child: MaterialButton(
+                    color: selectedIndex == currentIndex
+                        ? LUTheme.of(context).accentColor
+                        : null,
+                    onPressed: () {
+                      setState(() {
+                        selectedIndex = currentIndex;
+                      });
+                      widget.onPressed(widget.tipOptions[currentIndex]);
+                    },
+                    child: Container(
+                      child: Center(
+                          child: Text(
+                        widget
+                            .tipOptions[(index ~/ 2) % widget.tipOptions.length]
+                            .displayText,
+                        style: selectedIndex == currentIndex
+                            ? Styles.tipLabel.copyWith(
+                                color: LUTheme.of(context).backgroundColor)
+                            : Styles.tipLabel,
+                      )),
+                    ),
+                  ),
                 );
-              }
-              return Container(
-                color: LUTheme.of(context).unselectedWidgetColor,
-                child: Center(
-                    child: Text(
-                  tipOptions[(index ~/ 2) % tipOptions.length],
-                  style: Styles.tipLabel,
-                )),
-              );
-            }).toList()),
+              }).toList()),
+        ),
       ),
     );
   }

--- a/lib/components/tip_toolbar.dart
+++ b/lib/components/tip_toolbar.dart
@@ -1,0 +1,48 @@
+import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/utils/styles.dart';
+import 'package:flutter/material.dart';
+
+/// A bar containing buttons to select the desired tip value.
+class LUTipToolbar extends StatelessWidget {
+  final List<String> tipOptions;
+  final EdgeInsetsGeometry margin;
+
+  const LUTipToolbar({Key key, this.tipOptions, this.margin}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final List indexList =
+        Iterable<int>.generate(tipOptions.length + tipOptions.length - 1)
+            .toList();
+
+    return Padding(
+      padding: margin ?? EdgeInsets.zero,
+      child: Container(
+        height: 56.0,
+        decoration: BoxDecoration(
+            color: LUTheme.of(context).unselectedWidgetColor,
+            borderRadius: BorderRadius.circular(LUTheme.buttonBorderRadius)),
+        child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: indexList.map((index) {
+              if (index % 2 != 0) {
+                return VerticalDivider(
+                  width: 4,
+                  indent: 4,
+                  endIndent: 4,
+                  color: const Color(0X443C3C43),
+                );
+              }
+              return Container(
+                color: LUTheme.of(context).unselectedWidgetColor,
+                child: Center(
+                    child: Text(
+                  tipOptions[(index ~/ 2) % tipOptions.length],
+                  style: Styles.tipLabel,
+                )),
+              );
+            }).toList()),
+      ),
+    );
+  }
+}

--- a/lib/components/top_bar.dart
+++ b/lib/components/top_bar.dart
@@ -1,4 +1,5 @@
-import 'package:dr_app/utils/colors.dart';
+import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 
 import 'buttons/icon_button.dart';
@@ -8,6 +9,8 @@ class LUTopBar extends StatelessWidget {
   final EdgeInsetsGeometry padding;
   final IconData icon;
   final Color tint;
+  final String title;
+  final Color buttonBackgroundColor;
   final Function onNavigationButtonPressed;
   final List<Widget> children;
 
@@ -15,9 +18,11 @@ class LUTopBar extends StatelessWidget {
       {Key key,
       this.padding = const EdgeInsets.only(left: 16, right: 16, top: 8),
       this.icon = Icons.arrow_back_ios,
-      this.tint = LUColors.navyBlue,
+      this.tint,
       this.onNavigationButtonPressed,
-      this.children})
+      this.children,
+      this.buttonBackgroundColor,
+      this.title})
       : assert(children == null || onNavigationButtonPressed == null),
         super(key: key);
 
@@ -28,16 +33,29 @@ class LUTopBar extends StatelessWidget {
       child: Padding(
           padding: padding,
           child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              mainAxisAlignment: title != null
+                  ? MainAxisAlignment.start
+                  : MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: children ??
                   <Widget>[
                     LUIconButton(
                       icon: icon,
                       onPressed: onNavigationButtonPressed,
-                      tint: tint,
-                      backgroundColor: LUColors.smoothWhite,
+                      tint: tint ?? LUTheme.of(context).primaryColor,
+                      backgroundColor: buttonBackgroundColor ??
+                          LUTheme.of(context).backgroundColor,
                     ),
+                    title != null
+                        ? Padding(
+                            padding: const EdgeInsets.only(left: 16.0),
+                            child: Text(
+                              title,
+                              style: Styles.topBarTitle.copyWith(
+                                  color: LUTheme.of(context).primaryColor),
+                            ),
+                          )
+                        : Container()
                   ])),
     );
   }

--- a/lib/components/top_bar.dart
+++ b/lib/components/top_bar.dart
@@ -55,7 +55,7 @@ class LUTopBar extends StatelessWidget {
                                   color: LUTheme.of(context).primaryColor),
                             ),
                           )
-                        : Container()
+                        : SizedBox()
                   ])),
     );
   }

--- a/lib/data/dummy/dummy_data.dart
+++ b/lib/data/dummy/dummy_data.dart
@@ -1,8 +1,14 @@
+import 'package:credit_card_slider/card_background.dart';
+import 'package:credit_card_slider/card_company.dart';
+import 'package:credit_card_slider/card_network_type.dart';
+import 'package:credit_card_slider/credit_card_widget.dart';
+import 'package:credit_card_slider/validity.dart';
 import 'package:dr_app/data/models/chip_item.dart';
 import 'package:dr_app/data/models/cuisine_category.dart';
 import 'package:dr_app/data/models/dish.dart';
 import 'package:dr_app/data/models/featured_outlet.dart';
 import 'package:dr_app/data/models/outlet.dart';
+import 'package:flutter/material.dart';
 
 const dummyCards = [
   'Restaurant 1',
@@ -123,4 +129,86 @@ const List<Dish> dummyDishes = [
           'Classic Thai Street Food Dish With Rice Noodles & Roasted Peanuts',
       preparationTime: '12 min',
       priceTag: '£ 8.50'),
+];
+
+//final List<CreditCard> dummyCreditCards = [
+//  CreditCard(
+//    cardBackground: GradientCardBackground(LinearGradient(
+//      begin: Alignment.centerLeft,
+//      end: Alignment.centerRight,
+//      colors: [Color(0xFF4AA3F2), Color(0xFFAF92FB)],
+//      stops: [0.3, 0.95],
+//    )),
+//    cardNetworkType: CardNetworkType.visaBasic,
+//    cardHolderName: 'The boring developer',
+//  ),
+//  CreditCard(
+//    cardBackground: GradientCardBackground(LinearGradient(
+//      begin: Alignment.centerLeft,
+//      end: Alignment.centerRight,
+//      colors: [Color(0xFF4AA002), Color(0xFFAF92FB)],
+//      stops: [0.3, 0.95],
+//    )),
+//    cardNetworkType: CardNetworkType.visaBasic,
+//    cardHolderName: 'The boring developer',
+//  ),
+//  CreditCard(
+//    cardBackground: GradientCardBackground(LinearGradient(
+//      begin: Alignment.centerLeft,
+//      end: Alignment.centerRight,
+//      colors: [Color(0xFF4DDCC2), Color(0xFFAF92FB)],
+//      stops: [0.3, 0.95],
+//    )),
+//    cardNetworkType: CardNetworkType.visaBasic,
+//    cardHolderName: 'The boring developer',
+//  )
+//];
+
+var dummyCreditCards = [
+  CreditCard(
+    cardBackground: SolidColorCardBackground(Colors.black.withOpacity(0.6)),
+    cardNetworkType: CardNetworkType.visaBasic,
+    cardHolderName: 'The boring developer',
+    cardNumber: '1234 1234 1234 1234',
+    company: CardCompany.yesBank,
+    validity: Validity(
+      validThruMonth: 1,
+      validThruYear: 21,
+      validFromMonth: 1,
+      validFromYear: 16,
+    ),
+  ),
+  CreditCard(
+    cardBackground: SolidColorCardBackground(Colors.red.withOpacity(0.4)),
+    cardNetworkType: CardNetworkType.mastercard,
+    cardHolderName: 'Gursheesh Singh',
+    cardNumber: '2434 2434 **** ****',
+    company: CardCompany.kotak,
+    validity: Validity(
+      validThruMonth: 1,
+      validThruYear: 21,
+    ),
+  ),
+  CreditCard(
+    cardBackground: GradientCardBackground(LinearGradient(
+      begin: Alignment.centerLeft,
+      end: Alignment.centerRight,
+      colors: [Colors.blue, Colors.purple],
+      stops: [0.3, 0.95],
+    )),
+    cardNetworkType: CardNetworkType.mastercard,
+    cardHolderName: 'Very Very very boring devloper',
+    cardNumber: '4567',
+    company: CardCompany.sbiCard,
+    validity: Validity(
+      validThruMonth: 2,
+      validThruYear: 2021,
+    ),
+  ),
+  CreditCard(
+    cardNetworkType: CardNetworkType.rupay,
+    cardHolderName: 'THE BORING DEVELOPER',
+    cardNumber: '2434 2434 **** ****',
+    company: CardCompany.sbi,
+  ),
 ];

--- a/lib/data/dummy/dummy_data.dart
+++ b/lib/data/dummy/dummy_data.dart
@@ -205,10 +205,4 @@ var dummyCreditCards = [
       validThruYear: 2021,
     ),
   ),
-  CreditCard(
-    cardNetworkType: CardNetworkType.rupay,
-    cardHolderName: 'THE BORING DEVELOPER',
-    cardNumber: '2434 2434 **** ****',
-    company: CardCompany.sbi,
-  ),
 ];

--- a/lib/data/dummy/dummy_data.dart
+++ b/lib/data/dummy/dummy_data.dart
@@ -131,39 +131,6 @@ const List<Dish> dummyDishes = [
       priceTag: '£ 8.50'),
 ];
 
-//final List<CreditCard> dummyCreditCards = [
-//  CreditCard(
-//    cardBackground: GradientCardBackground(LinearGradient(
-//      begin: Alignment.centerLeft,
-//      end: Alignment.centerRight,
-//      colors: [Color(0xFF4AA3F2), Color(0xFFAF92FB)],
-//      stops: [0.3, 0.95],
-//    )),
-//    cardNetworkType: CardNetworkType.visaBasic,
-//    cardHolderName: 'The boring developer',
-//  ),
-//  CreditCard(
-//    cardBackground: GradientCardBackground(LinearGradient(
-//      begin: Alignment.centerLeft,
-//      end: Alignment.centerRight,
-//      colors: [Color(0xFF4AA002), Color(0xFFAF92FB)],
-//      stops: [0.3, 0.95],
-//    )),
-//    cardNetworkType: CardNetworkType.visaBasic,
-//    cardHolderName: 'The boring developer',
-//  ),
-//  CreditCard(
-//    cardBackground: GradientCardBackground(LinearGradient(
-//      begin: Alignment.centerLeft,
-//      end: Alignment.centerRight,
-//      colors: [Color(0xFF4DDCC2), Color(0xFFAF92FB)],
-//      stops: [0.3, 0.95],
-//    )),
-//    cardNetworkType: CardNetworkType.visaBasic,
-//    cardHolderName: 'The boring developer',
-//  )
-//];
-
 var dummyCreditCards = [
   CreditCard(
     cardBackground: SolidColorCardBackground(Colors.black.withOpacity(0.6)),

--- a/lib/data/models/tip.dart
+++ b/lib/data/models/tip.dart
@@ -1,0 +1,6 @@
+class Tip {
+  final String displayText;
+  final double value;
+
+  const Tip(this.displayText, this.value);
+}

--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -8,6 +8,7 @@ import 'package:dr_app/components/list.dart';
 import 'package:dr_app/components/round_container.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/data/dummy/dummy_data.dart';
+import 'package:dr_app/screens/payment_screen.dart';
 import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -171,7 +172,12 @@ class _CartScreenState extends State<CartScreen> {
                 title: 'Pay with credit card',
                 uppercase: false,
                 color: LUTheme.of(context).primaryColor,
-                onPressed: () {},
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => PaymentScreen()),
+                  );
+                },
               ),
             ],
           );

--- a/lib/screens/cuisine_screen.dart
+++ b/lib/screens/cuisine_screen.dart
@@ -45,6 +45,7 @@ class _CuisineScreenState extends State<CuisineScreen> {
           children: <Widget>[
             LUCompactHeader(
                 imgSrc: args.coverImgSrc,
+                icon: Icons.arrow_back_ios,
                 onTopButtonPressed: _onBackButtonPressed),
             _buildContent(args),
           ],

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -11,6 +11,7 @@ import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/data/dummy/dummy_data.dart';
 import 'package:dr_app/data/models/screen_arguments.dart';
 import 'package:dr_app/screens/outlet_screen.dart';
+import 'package:dr_app/screens/product_screen.dart';
 import 'package:dr_app/screens/scanner_screen.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
@@ -162,13 +163,17 @@ class _HomeContent extends StatelessWidget {
           ))
       .toList();
 
-  List<Widget> _getOutletCards() => dummyOutlets
+  List<Widget> _getOutletCards(context) => dummyOutlets
       .map((outlet) => LUOutletCard(
             imageSrc: outlet.imgSrc,
             rating: outlet.rating,
             title: outlet.name,
             priceRange: outlet.priceRange,
-            onPressed: () {},
+            onPressed: () {
+              Navigator.of(context).pushNamed(ProductScreen.id,
+                  arguments: ScreenArguments(
+                      title: outlet.name, coverImgSrc: outlet.imgSrc));
+            },
           ))
       .toList();
 
@@ -206,7 +211,7 @@ class _HomeContent extends StatelessWidget {
             child: LUList(
               nested: true,
               space: 10,
-              items: _getOutletCards(),
+              items: _getOutletCards(context),
             ),
           ),
         ]));

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -2,6 +2,7 @@ import 'package:dr_app/components/bottom_sliver.dart';
 import 'package:dr_app/components/tip_toolbar.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/data/models/tip.dart';
 import 'package:flutter/material.dart';
 
 class PaymentScreen extends StatefulWidget {
@@ -29,7 +30,15 @@ class _PaymentScreenState extends State<PaymentScreen> {
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 child: LUTipToolbar(
                   margin: EdgeInsets.only(top: 8.0),
-                  tipOptions: ['😢', '10%', '15%', '20%'],
+                  tipOptions: [
+                    Tip('😢', 0),
+                    Tip('10%', 0),
+                    Tip('15%', 0),
+                    Tip('20%', 0),
+                  ],
+                  onPressed: (tip) {
+                    print(tip.displayText);
+                  },
                 ),
               )
             ],

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -19,6 +19,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
             title: 'Payment',
             buttonBackgroundColor: LUTheme.of(context).primaryColor,
             tint: LUTheme.of(context).backgroundColor,
+            onNavigationButtonPressed: () => Navigator.of(context).pop(),
           ),
           Container(
             color: Colors.red,

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -8,6 +8,9 @@ import 'package:dr_app/data/dummy/dummy_data.dart';
 import 'package:dr_app/data/models/tip.dart';
 import 'package:flutter/material.dart';
 
+/// The Payment screen is the last step of the check-out flow.
+/// Here the user is able to select which card he/she wants to
+/// use for payment as well as the desired tip amount.
 class PaymentScreen extends StatefulWidget {
   static const id = 'payment_screen';
 
@@ -16,21 +19,6 @@ class PaymentScreen extends StatefulWidget {
 }
 
 class _PaymentScreenState extends State<PaymentScreen> {
-//  @override
-//  Widget build(BuildContext context) {
-//    return Scaffold(
-//      body: Center(
-//        child: CreditCardSlider(
-//          dummyCreditCards,
-//          initialCard: 2,
-//          onCardClicked: (index) {
-//            print('Clicked at index: $index');
-//          },
-//        ),
-//      ),
-//    );
-//  }
-
   double tipIncluded;
 
   @override
@@ -44,6 +32,23 @@ class _PaymentScreenState extends State<PaymentScreen> {
     return Scaffold(
       body: Stack(
         children: <Widget>[
+          SafeArea(
+            bottom: false,
+            child: CreditCardSlider(
+              dummyCreditCards,
+              initialCard: 0,
+              repeatCards: RepeatCards.bothDirection,
+              percentOfUpperCard: 0.8,
+              onCardClicked: (index) {
+                print('Clicked at index: $index');
+              },
+            ),
+          ),
+          SafeArea(
+            child: Container(
+                height: MediaQuery.of(context).size.height * 0.20,
+                color: LUTheme.of(context).backgroundColor),
+          ),
           Column(
             children: <Widget>[
               LUTopBar(
@@ -69,18 +74,6 @@ class _PaymentScreenState extends State<PaymentScreen> {
                       tipIncluded = tip.value;
                     });
                   },
-                ),
-              ),
-              SizedBox(
-                height: 600,
-                child: Center(
-                  child: CreditCardSlider(
-                    dummyCreditCards,
-                    initialCard: 2,
-                    onCardClicked: (index) {
-                      print('Clicked at index: $index');
-                    },
-                  ),
                 ),
               ),
             ],

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,4 +1,5 @@
 import 'package:dr_app/components/bottom_sliver.dart';
+import 'package:dr_app/components/tip_toolbar.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:flutter/material.dart';
@@ -24,10 +25,13 @@ class _PaymentScreenState extends State<PaymentScreen> {
                 tint: LUTheme.of(context).backgroundColor,
                 onNavigationButtonPressed: () => Navigator.of(context).pop(),
               ),
-              Container(
-                color: Colors.red,
-                height: 400,
-              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: LUTipToolbar(
+                  margin: EdgeInsets.only(top: 8.0),
+                  tipOptions: ['😢', '10%', '15%', '20%'],
+                ),
+              )
             ],
           ),
           Align(

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class PaymentScreen extends StatefulWidget {
+  static const id = 'payment_screen';
+
+  @override
+  _PaymentScreenState createState() => _PaymentScreenState();
+}
+
+class _PaymentScreenState extends State<PaymentScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.blue,
+    );
+  }
+}

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,8 +1,10 @@
+import 'package:credit_card_slider/credit_card_slider.dart';
 import 'package:dr_app/components/bottom_sliver.dart';
 import 'package:dr_app/components/section.dart';
 import 'package:dr_app/components/tip_toolbar.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/data/dummy/dummy_data.dart';
 import 'package:dr_app/data/models/tip.dart';
 import 'package:flutter/material.dart';
 
@@ -14,6 +16,21 @@ class PaymentScreen extends StatefulWidget {
 }
 
 class _PaymentScreenState extends State<PaymentScreen> {
+//  @override
+//  Widget build(BuildContext context) {
+//    return Scaffold(
+//      body: Center(
+//        child: CreditCardSlider(
+//          dummyCreditCards,
+//          initialCard: 2,
+//          onCardClicked: (index) {
+//            print('Clicked at index: $index');
+//          },
+//        ),
+//      ),
+//    );
+//  }
+
   double tipIncluded;
 
   @override
@@ -53,7 +70,19 @@ class _PaymentScreenState extends State<PaymentScreen> {
                     });
                   },
                 ),
-              )
+              ),
+              SizedBox(
+                height: 600,
+                child: Center(
+                  child: CreditCardSlider(
+                    dummyCreditCards,
+                    initialCard: 2,
+                    onCardClicked: (index) {
+                      print('Clicked at index: $index');
+                    },
+                  ),
+                ),
+              ),
             ],
           ),
           Align(

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,3 +1,5 @@
+import 'package:dr_app/components/top_bar.dart';
+import 'package:dr_app/configs/theme.dart';
 import 'package:flutter/material.dart';
 
 class PaymentScreen extends StatefulWidget {
@@ -10,8 +12,20 @@ class PaymentScreen extends StatefulWidget {
 class _PaymentScreenState extends State<PaymentScreen> {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.blue,
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          LUTopBar(
+            title: 'Payment',
+            buttonBackgroundColor: LUTheme.of(context).primaryColor,
+            tint: LUTheme.of(context).backgroundColor,
+          ),
+          Container(
+            color: Colors.red,
+            height: 400,
+          )
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dr_app/components/bottom_sliver.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:flutter/material.dart';
@@ -13,18 +14,29 @@ class _PaymentScreenState extends State<PaymentScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
+      body: Stack(
         children: <Widget>[
-          LUTopBar(
-            title: 'Payment',
-            buttonBackgroundColor: LUTheme.of(context).primaryColor,
-            tint: LUTheme.of(context).backgroundColor,
-            onNavigationButtonPressed: () => Navigator.of(context).pop(),
+          Column(
+            children: <Widget>[
+              LUTopBar(
+                title: 'Payment',
+                buttonBackgroundColor: LUTheme.of(context).primaryColor,
+                tint: LUTheme.of(context).backgroundColor,
+                onNavigationButtonPressed: () => Navigator.of(context).pop(),
+              ),
+              Container(
+                color: Colors.red,
+                height: 400,
+              ),
+            ],
           ),
-          Container(
-            color: Colors.red,
-            height: 400,
-          )
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: LUBottomSliver(
+              buttonTitle: 'pay',
+              onButtonPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -14,6 +14,14 @@ class PaymentScreen extends StatefulWidget {
 }
 
 class _PaymentScreenState extends State<PaymentScreen> {
+  double tipIncluded;
+
+  @override
+  void initState() {
+    super.initState();
+    tipIncluded = 0.0;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -33,13 +41,16 @@ class _PaymentScreenState extends State<PaymentScreen> {
                 child: LUTipToolbar(
                   margin: EdgeInsets.symmetric(horizontal: 16.0),
                   tipOptions: [
-                    Tip('😢', 0),
-                    Tip('10%', 0),
-                    Tip('15%', 0),
-                    Tip('20%', 0),
+                    Tip('😢', 0.0),
+                    Tip('10%', 0.10),
+                    Tip('15%', 0.15),
+                    Tip('20%', 0.20),
                   ],
                   onPressed: (tip) {
                     print(tip.displayText);
+                    setState(() {
+                      tipIncluded = tip.value;
+                    });
                   },
                 ),
               )
@@ -49,6 +60,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
             alignment: Alignment.bottomCenter,
             child: LUBottomSliver(
               buttonTitle: 'pay',
+              tip: tipIncluded,
               onButtonPressed: () => Navigator.of(context).pop(),
             ),
           ),

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,4 +1,5 @@
 import 'package:dr_app/components/bottom_sliver.dart';
+import 'package:dr_app/components/section.dart';
 import 'package:dr_app/components/tip_toolbar.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
@@ -26,10 +27,11 @@ class _PaymentScreenState extends State<PaymentScreen> {
                 tint: LUTheme.of(context).backgroundColor,
                 onNavigationButtonPressed: () => Navigator.of(context).pop(),
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              LUSection(
+                title: 'Tip the service',
+                margin: EdgeInsets.only(top: 32.0),
                 child: LUTipToolbar(
-                  margin: EdgeInsets.only(top: 8.0),
+                  margin: EdgeInsets.symmetric(horizontal: 16.0),
                   tipOptions: [
                     Tip('😢', 0),
                     Tip('10%', 0),

--- a/lib/utils/styles.dart
+++ b/lib/utils/styles.dart
@@ -72,6 +72,8 @@ abstract class Styles {
       fontSize: 20, fontWeight: FontWeight.w600, color: LUColors.darkBlue);
   static const topBarTitle =
       TextStyle(fontSize: 28, fontWeight: FontWeight.bold);
+  static const tipLabel = TextStyle(
+      fontSize: 22, fontWeight: FontWeight.w400, color: LUColors.darkBlue);
 
   /// Container Styles
   static const double roundContainerHeight = 240;

--- a/lib/utils/styles.dart
+++ b/lib/utils/styles.dart
@@ -70,6 +70,8 @@ abstract class Styles {
       fontSize: 14, color: LUColors.darkBlue, fontWeight: FontWeight.w600);
   static const bottomSheetTitle = TextStyle(
       fontSize: 20, fontWeight: FontWeight.w600, color: LUColors.darkBlue);
+  static const topBarTitle =
+      TextStyle(fontSize: 28, fontWeight: FontWeight.bold);
 
   /// Container Styles
   static const double roundContainerHeight = 240;

--- a/lib/utils/styles.dart
+++ b/lib/utils/styles.dart
@@ -74,6 +74,8 @@ abstract class Styles {
       TextStyle(fontSize: 28, fontWeight: FontWeight.bold);
   static const tipLabel = TextStyle(
       fontSize: 22, fontWeight: FontWeight.w400, color: LUColors.darkBlue);
+  static const tipIncludedText = TextStyle(
+      fontSize: 14, fontWeight: FontWeight.w400, color: LUColors.darkBlue);
 
   /// Container Styles
   static const double roundContainerHeight = 240;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -22,6 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.1"
+  auto_size_text:
+    dependency: transitive
+    description:
+      name: auto_size_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -50,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  credit_card_slider:
+    dependency: "direct main"
+    description:
+      name: credit_card_slider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   crypto:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   flutter_swiper: ^1.1.6
   flutter_page_indicator: ^0.0.3
   slide_to_confirm: ^0.0.6
+  credit_card_slider: ^1.0.1
 
   # Custom Capabilities
   qr_code_scanner:


### PR DESCRIPTION
# Card Payment Screen

**Result**
<img width="470" alt="Screenshot 2020-07-29 at 12 53 34" src="https://user-images.githubusercontent.com/11461969/88797009-8b45d600-d19a-11ea-803c-d05a1a7c16b0.png">

**Highlights**
- Create `PaymentScreen` and link it with `CartScreen`
- Add title property to `LUTopBar`
- Add `LUBottomSliver`
- Create `LUTipToolbar` component
- Include tip label on bottom sliver
- Add [credit_card_slider](https://github.com/GursheeshSingh/creditcard_slider) dependency
- Fix LUTopBar layout
- Upgrade Android minSdkVersion to 19
- Add documentation
