### PR TITLE
#60 Edit Profile Information Screen

### DIFF
--- a/lib/components/input_field.dart
+++ b/lib/components/input_field.dart
@@ -7,8 +7,15 @@ import 'package:flutter/material.dart';
 class LUInputField extends StatelessWidget {
   final String fieldTitle;
   final String hintText;
+  final bool obscureText;
+  final TextInputType keyboardType;
 
-  const LUInputField({Key key, this.fieldTitle, this.hintText})
+  const LUInputField(
+      {Key key,
+      this.fieldTitle,
+      this.hintText,
+      this.obscureText = false,
+      this.keyboardType})
       : super(key: key);
 
   @override
@@ -28,7 +35,8 @@ class LUInputField extends StatelessWidget {
           ),
           TextFormField(
             autofocus: true,
-            keyboardType: TextInputType.number,
+            obscureText: obscureText,
+            keyboardType: keyboardType,
             style: Styles.formInputText,
             decoration: InputDecoration(
               contentPadding: EdgeInsets.all(8),

--- a/lib/configs/routes.dart
+++ b/lib/configs/routes.dart
@@ -1,6 +1,7 @@
 import 'package:dr_app/screens/add_credit_card_screen.dart';
 import 'package:dr_app/screens/category_detail_screen.dart';
 import 'package:dr_app/screens/cuisine_screen.dart';
+import 'package:dr_app/screens/edit_profile_screen.dart';
 import 'package:dr_app/screens/explore_screen.dart';
 import 'package:dr_app/screens/favorites_screen.dart';
 import 'package:dr_app/screens/home_screen.dart';
@@ -30,6 +31,7 @@ final Map<String, WidgetBuilder> routes = {
   FavoritesScreen.id: (context) => FavoritesScreen(),
   LastVisitedScreen.id: (context) => LastVisitedScreen(),
   AddCreditCardScreen.id: (context) => AddCreditCardScreen(),
+  EditProfileScreen.id: (context) => EditProfileScreen()
 };
 
 final Set<String> fullScreenRoutes = {ScannerScreen.id};

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -1,22 +1,21 @@
 import 'package:dr_app/components/buttons/solid_button.dart';
-import 'package:dr_app/components/cards/tile_option_card.dart';
-import 'package:dr_app/components/list.dart';
 import 'package:dr_app/configs/theme.dart';
-import 'package:dr_app/screens/edit_profile_screen.dart';
-import 'package:dr_app/screens/favorites_screen.dart';
-import 'package:dr_app/screens/last_visited_screen.dart';
-import 'package:dr_app/screens/wallet_screen.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
 import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 
-/// The profile screen displays personalized options to the authenticated user.
-/// Here the user can navigate to the payment methods,favorite restaurants, and
-/// last visited restaurants.
-class ProfileScreen extends StatelessWidget {
-  static const id = 'profile_screen';
+/// The EditProfileScreen makes it possible for the user
+/// to edit profile-related information such as fullname,
+/// email, and password.
+class EditProfileScreen extends StatefulWidget {
+  static const id = 'edit_profile_screen';
 
+  @override
+  _EditProfileScreenState createState() => _EditProfileScreenState();
+}
+
+class _EditProfileScreenState extends State<EditProfileScreen> {
   static const double profilePictureSize = 160;
   static const double headerHeightFactor = 0.35;
 
@@ -26,14 +25,14 @@ class ProfileScreen extends StatelessWidget {
       color: LUTheme.of(context).backgroundColor,
       child: Column(
         children: <Widget>[
-          buildProfileHeader(context),
-          buildProfileContent(context),
+          buildEditProfileHeader(context),
+          buildEditProfileContent(context),
         ],
       ),
     );
   }
 
-  Widget buildProfileHeader(BuildContext context) => Container(
+  Widget buildEditProfileHeader(BuildContext context) => Container(
         height: MediaQuery.of(context).size.height * headerHeightFactor + 32,
         child: Stack(
           children: <Widget>[
@@ -123,8 +122,7 @@ class ProfileScreen extends StatelessWidget {
                                 FlatButton(
                                   padding: const EdgeInsets.symmetric(
                                       vertical: 0.0, horizontal: 4.0),
-                                  onPressed: () => Navigator.of(context)
-                                      .pushNamed(EditProfileScreen.id),
+                                  onPressed: () {},
                                   child: Text(
                                     'Edit Profile',
                                     style: Styles.profileButtonText,
@@ -144,40 +142,16 @@ class ProfileScreen extends StatelessWidget {
         ),
       );
 
-  Widget buildProfileContent(BuildContext context) => Expanded(
+  Widget buildEditProfileContent(BuildContext context) => Expanded(
         child: Container(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[
-              LUList(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 32),
-                nested: true,
-                items: <Widget>[
-                  LUTileOptionCard(
-                    leadingIcon: Icons.credit_card,
-                    title: 'Wallet',
-                    onPressed: () =>
-                        Navigator.of(context).pushNamed(WalletScreen.id),
-                  ),
-                  LUTileOptionCard(
-                    leadingIcon: Icons.favorite_border,
-                    title: 'Favorite restaurants',
-                    onPressed: () =>
-                        Navigator.of(context).pushNamed(FavoritesScreen.id),
-                  ),
-                  LUTileOptionCard(
-                    leadingIcon: Icons.history,
-                    title: 'Visited restaurants',
-                    onPressed: () =>
-                        Navigator.of(context).pushNamed(LastVisitedScreen.id),
-                  ),
-                ],
-              ),
+              Text('Nice'),
               LUSolidButton(
                 onPressed: () {},
-                title: 'logout',
+                title: 'save',
               )
             ],
           ),

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -1,4 +1,5 @@
 import 'package:dr_app/components/buttons/solid_button.dart';
+import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
@@ -17,7 +18,7 @@ class EditProfileScreen extends StatefulWidget {
 
 class _EditProfileScreenState extends State<EditProfileScreen> {
   static const double profilePictureSize = 160;
-  static const double headerHeightFactor = 0.35;
+  static const double headerHeightFactor = 0.30;
 
   @override
   Widget build(BuildContext context) {
@@ -53,7 +54,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 borderRadius:
                     BorderRadius.only(bottomLeft: Styles.roundBackgroundRadius),
                 child: Container(
-                  height: MediaQuery.of(context).size.height * 0.35,
+                  height:
+                      MediaQuery.of(context).size.height * headerHeightFactor,
                   color: LUColors.yellow,
                   child: Stack(
                     children: <Widget>[
@@ -71,7 +73,6 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 mainAxisAlignment: MainAxisAlignment.end,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: <Widget>[
-                  Text('Profile', style: Styles.profileTitle),
                   SizedBox(
                     height: 40,
                   ),
@@ -97,38 +98,37 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                               color: Colors.white,
                               borderRadius: BorderRadius.all(
                                   Radius.circular(LUTheme.cardBorderRadius))),
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(
-                                LUTheme.cardBorderRadius - 4),
-                            child: FadeInImage.assetNetwork(
-                              placeholder: Images.verticalPlaceholder,
-                              image: 'https://picsum.photos/400/300?random=2',
-                              fit: BoxFit.cover,
-                            ),
+                          child: Stack(
+                            children: <Widget>[
+                              Positioned.fill(
+                                child: ClipRRect(
+                                  borderRadius: BorderRadius.circular(
+                                      LUTheme.cardBorderRadius - 4),
+                                  child: FadeInImage.assetNetwork(
+                                    placeholder: Images.verticalPlaceholder,
+                                    image:
+                                        'https://picsum.photos/400/300?random=2',
+                                    fit: BoxFit.cover,
+                                  ),
+                                ),
+                              ),
+                              Center(
+                                child: Icon(
+                                  Icons.camera_alt,
+                                  size: 80,
+                                  color: LUColors.smoothGray.withOpacity(0.9),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                         Padding(
                           padding: const EdgeInsets.only(bottom: 24, top: 24),
                           child: Padding(
                             padding: const EdgeInsets.only(left: 16),
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
-                                Text(
-                                  'Amanda \n\nBaggins',
-                                  style: Styles.sloganTitle,
-                                ),
-                                FlatButton(
-                                  padding: const EdgeInsets.symmetric(
-                                      vertical: 0.0, horizontal: 4.0),
-                                  onPressed: () {},
-                                  child: Text(
-                                    'Edit Profile',
-                                    style: Styles.profileButtonText,
-                                  ),
-                                )
-                              ],
+                            child: Text(
+                              'Amanda \n\nBaggins',
+                              style: Styles.sloganTitle,
                             ),
                           ),
                         )
@@ -136,6 +136,12 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                     ),
                   )
                 ],
+              ),
+            ),
+            SafeArea(
+              child: LUTopBar(
+                title: 'Edit Profile',
+                onNavigationButtonPressed: () => Navigator.of(context).pop(),
               ),
             )
           ],

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -33,6 +33,46 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     );
   }
 
+  Widget buildAvatar() => Container(
+        width: profilePictureSize,
+        height: profilePictureSize,
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.shade300.withOpacity(0.5),
+                spreadRadius: 2,
+                blurRadius: 8,
+                offset: Offset(0, 2), // changes position of shadow
+              )
+            ],
+            color: Colors.white,
+            borderRadius:
+                BorderRadius.all(Radius.circular(LUTheme.cardBorderRadius))),
+        child: Stack(
+          children: <Widget>[
+            Positioned.fill(
+              child: ClipRRect(
+                borderRadius:
+                    BorderRadius.circular(LUTheme.cardBorderRadius - 4),
+                child: FadeInImage.assetNetwork(
+                  placeholder: Images.verticalPlaceholder,
+                  image: 'https://picsum.photos/400/300?random=2',
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
+            Center(
+              child: Icon(
+                Icons.camera_alt,
+                size: 80,
+                color: LUColors.smoothGray.withOpacity(0.9),
+              ),
+            ),
+          ],
+        ),
+      );
+
   Widget buildEditProfileHeader(BuildContext context) => Container(
         height: MediaQuery.of(context).size.height * headerHeightFactor + 32,
         child: Stack(
@@ -81,47 +121,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                     child: Row(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: <Widget>[
-                        Container(
-                          width: profilePictureSize,
-                          height: profilePictureSize,
-                          padding: const EdgeInsets.all(8),
-                          decoration: BoxDecoration(
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Colors.grey.shade300.withOpacity(0.5),
-                                  spreadRadius: 2,
-                                  blurRadius: 8,
-                                  offset: Offset(
-                                      0, 2), // changes position of shadow
-                                )
-                              ],
-                              color: Colors.white,
-                              borderRadius: BorderRadius.all(
-                                  Radius.circular(LUTheme.cardBorderRadius))),
-                          child: Stack(
-                            children: <Widget>[
-                              Positioned.fill(
-                                child: ClipRRect(
-                                  borderRadius: BorderRadius.circular(
-                                      LUTheme.cardBorderRadius - 4),
-                                  child: FadeInImage.assetNetwork(
-                                    placeholder: Images.verticalPlaceholder,
-                                    image:
-                                        'https://picsum.photos/400/300?random=2',
-                                    fit: BoxFit.cover,
-                                  ),
-                                ),
-                              ),
-                              Center(
-                                child: Icon(
-                                  Icons.camera_alt,
-                                  size: 80,
-                                  color: LUColors.smoothGray.withOpacity(0.9),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
+                        buildAvatar(),
                         Padding(
                           padding: const EdgeInsets.only(bottom: 24, top: 24),
                           child: Padding(

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -35,6 +35,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     );
   }
 
+  // TODO: Implement camera logic
   Widget buildAvatar() => Container(
         width: profilePictureSize,
         height: profilePictureSize,
@@ -150,22 +151,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
         ),
       );
 
-//  Widget buildEditProfileContent(BuildContext context) => Expanded(
-//        child: Container(
-//          child: Column(
-//            mainAxisSize: MainAxisSize.min,
-//            mainAxisAlignment: MainAxisAlignment.start,
-//            children: <Widget>[
-//              Text('Nice'),
-//              LUSolidButton(
-//                onPressed: () {},
-//                title: 'save',
-//              )
-//            ],
-//          ),
-//        ),
-//      );
-
+  // TODO: Implement validation logic
   Widget buildEditProfileContent(BuildContext context) => Expanded(
         child: Container(
             child: LUList(
@@ -198,7 +184,9 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             ),
             LUSolidButton(
               margin: EdgeInsets.symmetric(vertical: 32.0),
-              onPressed: () {},
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
               title: 'save',
             )
           ],

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -1,4 +1,6 @@
 import 'package:dr_app/components/buttons/solid_button.dart';
+import 'package:dr_app/components/input_field.dart';
+import 'package:dr_app/components/list.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/utils/colors.dart';
@@ -148,19 +150,58 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
         ),
       );
 
+//  Widget buildEditProfileContent(BuildContext context) => Expanded(
+//        child: Container(
+//          child: Column(
+//            mainAxisSize: MainAxisSize.min,
+//            mainAxisAlignment: MainAxisAlignment.start,
+//            children: <Widget>[
+//              Text('Nice'),
+//              LUSolidButton(
+//                onPressed: () {},
+//                title: 'save',
+//              )
+//            ],
+//          ),
+//        ),
+//      );
+
   Widget buildEditProfileContent(BuildContext context) => Expanded(
         child: Container(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.start,
-            children: <Widget>[
-              Text('Nice'),
-              LUSolidButton(
-                onPressed: () {},
-                title: 'save',
-              )
-            ],
-          ),
-        ),
+            child: LUList(
+          padding: EdgeInsets.symmetric(horizontal: 32.0),
+          items: <Widget>[
+            Form(
+              child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    LUInputField(
+                      fieldTitle: 'Full Name',
+                      hintText: 'Amanda Baggins',
+                      keyboardType: TextInputType.text,
+                    ),
+                    LUInputField(
+                        fieldTitle: 'Email',
+                        hintText: 'amanda@email.com',
+                        keyboardType: TextInputType.emailAddress),
+                    LUInputField(
+                        obscureText: true,
+                        fieldTitle: 'Password',
+                        hintText: '123456',
+                        keyboardType: TextInputType.text),
+                    LUInputField(
+                        obscureText: true,
+                        fieldTitle: 'Repeat Password',
+                        hintText: '123456',
+                        keyboardType: TextInputType.text),
+                  ]),
+            ),
+            LUSolidButton(
+              margin: EdgeInsets.symmetric(vertical: 32.0),
+              onPressed: () {},
+              title: 'save',
+            )
+          ],
+        )),
       );
 }

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -18,7 +18,7 @@ class ProfileScreen extends StatelessWidget {
   static const id = 'profile_screen';
 
   static const double profilePictureSize = 160;
-  static const double headerHeightFactor = 0.35;
+  static const double headerHeightFactor = 0.30;
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +54,8 @@ class ProfileScreen extends StatelessWidget {
                 borderRadius:
                     BorderRadius.only(bottomLeft: Styles.roundBackgroundRadius),
                 child: Container(
-                  height: MediaQuery.of(context).size.height * 0.35,
+                  height:
+                      MediaQuery.of(context).size.height * headerHeightFactor,
                   color: LUColors.yellow,
                   child: Stack(
                     children: <Widget>[


### PR DESCRIPTION
# Basic Edit Profile Screen

**Results**
<img width="470" alt="Screenshot 2020-08-04 at 11 48 53" src="https://user-images.githubusercontent.com/11461969/89285577-8bd1e700-d648-11ea-9492-53780dfd8b4f.png">

**Highlights**
- Create `EditProfileScreen` and register its route
- Link `EditProfileScreen` with `ProfileScreen`
- Modify header height factor from 0.35 to 0.30

**Notes**
- All state still must be wired up (including form validation)
- This screen requires [camera integration](https://flutter.dev/docs/cookbook/plugins/picture-using-camera)

