### PR TITLE
#61 Login Screen (UI)

### DIFF
--- a/lib/configs/routes.dart
+++ b/lib/configs/routes.dart
@@ -6,6 +6,7 @@ import 'package:dr_app/screens/explore_screen.dart';
 import 'package:dr_app/screens/favorites_screen.dart';
 import 'package:dr_app/screens/home_screen.dart';
 import 'package:dr_app/screens/last_visited_screen.dart';
+import 'package:dr_app/screens/login_screen.dart';
 import 'package:dr_app/screens/more_screen.dart';
 import 'package:dr_app/screens/outlet_detail_screen.dart';
 import 'package:dr_app/screens/outlet_screen.dart';
@@ -31,7 +32,8 @@ final Map<String, WidgetBuilder> routes = {
   FavoritesScreen.id: (context) => FavoritesScreen(),
   LastVisitedScreen.id: (context) => LastVisitedScreen(),
   AddCreditCardScreen.id: (context) => AddCreditCardScreen(),
-  EditProfileScreen.id: (context) => EditProfileScreen()
+  EditProfileScreen.id: (context) => EditProfileScreen(),
+  LoginScreen.id: (context) => LoginScreen(),
 };
 
 final Set<String> fullScreenRoutes = {ScannerScreen.id};

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,3 +1,5 @@
+import 'package:dr_app/components/buttons/solid_button.dart';
+import 'package:dr_app/components/input_field.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/utils/colors.dart';
@@ -40,7 +42,6 @@ class _LoginScreenState extends State<LoginScreen> {
           ),
           SafeArea(
               child: LUTopBar(
-            title: 'Login',
             onNavigationButtonPressed: () => Navigator.of(context).pop(),
           )),
           SafeArea(
@@ -73,7 +74,47 @@ class _LoginScreenState extends State<LoginScreen> {
   }
 
   Widget buildLoginBody() {
-    return SizedBox();
+    final bodySize = (1 - headerHeightFactor - footerHeightFactor);
+
+    return Align(
+      alignment: Alignment.center,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 32.0),
+        height: MediaQuery.of(context).size.height * bodySize,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Login',
+              style: Styles.topBarTitle
+                  .copyWith(color: LUTheme.of(context).primaryColor),
+            ),
+            Form(
+              child: Column(
+                children: <Widget>[
+                  LUInputField(
+                      fieldTitle: 'Email',
+                      hintText: 'amanda@email.com',
+                      keyboardType: TextInputType.emailAddress),
+                  LUInputField(
+                      obscureText: true,
+                      fieldTitle: 'Password',
+                      hintText: '123456',
+                      keyboardType: TextInputType.text),
+                ],
+              ),
+            ),
+            Center(
+              child: LUSolidButton(
+                title: 'Login',
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -90,27 +90,39 @@ class _LoginScreenState extends State<LoginScreen> {
               style: Styles.topBarTitle
                   .copyWith(color: LUTheme.of(context).primaryColor),
             ),
-            Form(
-              child: Column(
-                children: <Widget>[
-                  LUInputField(
-                      fieldTitle: 'Email',
-                      hintText: 'amanda@email.com',
-                      keyboardType: TextInputType.emailAddress),
-                  LUInputField(
-                      obscureText: true,
-                      fieldTitle: 'Password',
-                      hintText: '123456',
-                      keyboardType: TextInputType.text),
-                ],
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16.0),
+              child: Form(
+                child: Column(
+                  children: <Widget>[
+                    LUInputField(
+                        fieldTitle: 'Email',
+                        hintText: 'amanda@email.com',
+                        keyboardType: TextInputType.emailAddress),
+                    LUInputField(
+                        obscureText: true,
+                        fieldTitle: 'Password',
+                        hintText: '123456',
+                        keyboardType: TextInputType.text),
+                  ],
+                ),
               ),
             ),
             Center(
-              child: LUSolidButton(
-                title: 'Login',
-                onPressed: () => Navigator.of(context).pop(),
+              child: Column(
+                children: <Widget>[
+                  LUSolidButton(
+                    title: 'Login',
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                  FlatButton(
+                    onPressed: () {},
+                    child:
+                        Text('Forgot password?', style: Styles.loginFooterText),
+                  ),
+                ],
               ),
-            )
+            ),
           ],
         ),
       ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -16,6 +16,7 @@ class LoginScreen extends StatefulWidget {
   _LoginScreenState createState() => _LoginScreenState();
 }
 
+// TODO: Implement state management and validation
 class _LoginScreenState extends State<LoginScreen> {
   static const headerHeightFactor = 0.28;
   static const footerHeightFactor = 0.28;

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,20 @@
+import 'package:dr_app/configs/theme.dart';
+import 'package:flutter/material.dart';
+
+/// The LoginScreen displays an input form which
+/// allows users to authenticate using their account credentials.
+class LoginScreen extends StatefulWidget {
+  static const id = 'login_screen';
+
+  @override
+  _LoginScreenState createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: LUTheme.of(context).backgroundColor,
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,4 +1,6 @@
 import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/utils/colors.dart';
+import 'package:dr_app/utils/images.dart';
 import 'package:flutter/material.dart';
 
 /// The LoginScreen displays an input form which
@@ -11,10 +13,93 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
+  static const headerHeightFactor = 0.28;
+  static const footerHeightFactor = 0.28;
+  static const shapeBorderRadius = Radius.elliptical(720, 360);
+
   @override
   Widget build(BuildContext context) {
     return Container(
       color: LUTheme.of(context).backgroundColor,
+      child: Stack(
+        children: <Widget>[
+          buildLoginHeader(),
+          buildLoginBody(),
+          buildLoginFooter()
+        ],
+      ),
+    );
+  }
+
+  Widget buildLoginHeader() {
+    return _LoginBackgroundShape(
+        shapeBorderRadius: shapeBorderRadius,
+        context: context,
+        headerHeightFactor: headerHeightFactor);
+  }
+
+  Widget buildLoginBody() {
+    return SizedBox();
+  }
+
+  Widget buildLoginFooter() {
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: _LoginBackgroundShape(
+          invert: true,
+          shapeBorderRadius: shapeBorderRadius,
+          context: context,
+          headerHeightFactor: footerHeightFactor),
+    );
+  }
+}
+
+class _LoginBackgroundShape extends StatelessWidget {
+  final Radius shapeBorderRadius;
+  final BuildContext context;
+  final double headerHeightFactor;
+  final bool invert;
+
+  const _LoginBackgroundShape({
+    Key key,
+    @required this.shapeBorderRadius,
+    @required this.context,
+    @required this.headerHeightFactor,
+    this.invert = false,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius = invert
+        ? BorderRadius.only(topLeft: shapeBorderRadius)
+        : BorderRadius.only(bottomRight: shapeBorderRadius);
+
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: borderRadius,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.shade300.withOpacity(0.5),
+            spreadRadius: 2,
+            blurRadius: 8,
+            offset: Offset(0, invert ? -2 : 2), // changes position of shadow
+          )
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: borderRadius,
+        child: Container(
+          height: MediaQuery.of(context).size.height * headerHeightFactor,
+          color: LUColors.yellow,
+          child: Stack(
+            children: <Widget>[
+              Positioned.fill(
+                  child: Image.asset(Images.homeHeaderBackground,
+                      fit: BoxFit.cover)),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,6 +1,8 @@
+import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
+import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 
 /// The LoginScreen displays an input form which
@@ -23,34 +25,55 @@ class _LoginScreenState extends State<LoginScreen> {
       color: LUTheme.of(context).backgroundColor,
       child: Stack(
         children: <Widget>[
-          buildLoginHeader(),
+          _LoginBackgroundShape(
+              shapeBorderRadius: shapeBorderRadius,
+              context: context,
+              headerHeightFactor: headerHeightFactor),
           buildLoginBody(),
-          buildLoginFooter()
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: _LoginBackgroundShape(
+                invert: true,
+                shapeBorderRadius: shapeBorderRadius,
+                context: context,
+                headerHeightFactor: footerHeightFactor),
+          ),
+          SafeArea(
+              child: LUTopBar(
+            title: 'Login',
+            onNavigationButtonPressed: () => Navigator.of(context).pop(),
+          )),
+          SafeArea(
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Text(
+                    "Don't have an account?",
+                    style: Styles.loginFooterText,
+                  ),
+                  FlatButton(
+                    padding: const EdgeInsets.symmetric(
+                        vertical: 0.0, horizontal: 4.0),
+                    onPressed: () {},
+                    child: Text(
+                      'Sign Up',
+                      style: Styles.loginFooterText
+                          .copyWith(fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          )
         ],
       ),
     );
   }
 
-  Widget buildLoginHeader() {
-    return _LoginBackgroundShape(
-        shapeBorderRadius: shapeBorderRadius,
-        context: context,
-        headerHeightFactor: headerHeightFactor);
-  }
-
   Widget buildLoginBody() {
     return SizedBox();
-  }
-
-  Widget buildLoginFooter() {
-    return Align(
-      alignment: Alignment.bottomCenter,
-      child: _LoginBackgroundShape(
-          invert: true,
-          shapeBorderRadius: shapeBorderRadius,
-          context: context,
-          headerHeightFactor: footerHeightFactor),
-    );
   }
 }
 

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -5,6 +5,7 @@ import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/screens/edit_profile_screen.dart';
 import 'package:dr_app/screens/favorites_screen.dart';
 import 'package:dr_app/screens/last_visited_screen.dart';
+import 'package:dr_app/screens/login_screen.dart';
 import 'package:dr_app/screens/wallet_screen.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
@@ -177,7 +178,9 @@ class ProfileScreen extends StatelessWidget {
                 ],
               ),
               LUSolidButton(
-                onPressed: () {},
+                onPressed: () {
+                  Navigator.of(context).pushNamed(LoginScreen.id);
+                },
                 title: 'logout',
               )
             ],

--- a/lib/utils/styles.dart
+++ b/lib/utils/styles.dart
@@ -109,6 +109,8 @@ abstract class Styles {
       fontSize: 12, fontWeight: FontWeight.w600, color: LUColors.gray);
   static const formInputText = TextStyle(
       fontSize: 18, fontWeight: FontWeight.w400, color: LUColors.darkBlue);
+  static const loginFooterText = TextStyle(
+      fontSize: 17, fontWeight: FontWeight.w400, color: LUColors.navyBlue);
 
   /// Container Styles
   static const roundBackgroundRadius = Radius.circular(40.0);


### PR DESCRIPTION
# Basic Login Screen

**Results**
<img width="470" alt="Screenshot 2020-08-04 at 12 56 53" src="https://user-images.githubusercontent.com/11461969/89291236-1703aa80-d652-11ea-8529-dc64beb6ab68.png">

**Highlights**
- Create `LoginScreen` and register its routes
- Link `LoginScreen` temporarily with `ProfileScreen` 's logout button
- Add sign up and password recovery options

**Notes**
- No state management nor validations have been implemented yet
- TODO: test the layout for tiny screen sizes