### PR TITLE
#62 SignUp Screen (UI)

### DIFF
--- a/lib/components/round_avatar.dart
+++ b/lib/components/round_avatar.dart
@@ -1,0 +1,60 @@
+import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/utils/colors.dart';
+import 'package:dr_app/utils/images.dart';
+import 'package:flutter/material.dart';
+
+/// A round rectangle container which displays an image source.
+/// Often used to display a user's profile picture.
+class LURectangleAvatar extends StatelessWidget {
+  final double profilePictureSize;
+  final bool editable;
+
+  const LURectangleAvatar({
+    Key key,
+    @required this.profilePictureSize,
+    this.editable = false,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => Container(
+        width: profilePictureSize,
+        height: profilePictureSize,
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.shade300.withOpacity(0.5),
+                spreadRadius: 2,
+                blurRadius: 8,
+                offset: Offset(0, 2), // changes position of shadow
+              )
+            ],
+            color: Colors.white,
+            borderRadius:
+                BorderRadius.all(Radius.circular(LUTheme.cardBorderRadius))),
+        child: Stack(
+          children: <Widget>[
+            Positioned.fill(
+              child: ClipRRect(
+                borderRadius:
+                    BorderRadius.circular(LUTheme.cardBorderRadius - 4),
+                child: FadeInImage.assetNetwork(
+                  placeholder: Images.verticalPlaceholder,
+                  image: 'https://picsum.photos/400/300?random=2',
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
+            editable
+                ? Center(
+                    child: Icon(
+                      Icons.camera_alt,
+                      size: 80,
+                      color: LUColors.smoothGray.withOpacity(0.9),
+                    ),
+                  )
+                : SizedBox()
+          ],
+        ),
+      );
+}

--- a/lib/configs/routes.dart
+++ b/lib/configs/routes.dart
@@ -13,6 +13,7 @@ import 'package:dr_app/screens/outlet_screen.dart';
 import 'package:dr_app/screens/product_screen.dart';
 import 'package:dr_app/screens/profile_screen.dart';
 import 'package:dr_app/screens/scanner_screen.dart';
+import 'package:dr_app/screens/signup_screen.dart';
 import 'package:dr_app/screens/wallet_screen.dart';
 import 'package:flutter/widgets.dart';
 
@@ -34,6 +35,7 @@ final Map<String, WidgetBuilder> routes = {
   AddCreditCardScreen.id: (context) => AddCreditCardScreen(),
   EditProfileScreen.id: (context) => EditProfileScreen(),
   LoginScreen.id: (context) => LoginScreen(),
+  SignUpScreen.id: (context) => SignUpScreen()
 };
 
 final Set<String> fullScreenRoutes = {ScannerScreen.id};

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dr_app/components/buttons/solid_button.dart';
 import 'package:dr_app/components/input_field.dart';
 import 'package:dr_app/components/list.dart';
+import 'package:dr_app/components/round_avatar.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/utils/colors.dart';
@@ -36,45 +37,6 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   }
 
   // TODO: Implement camera logic
-  Widget buildAvatar() => Container(
-        width: profilePictureSize,
-        height: profilePictureSize,
-        padding: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-            boxShadow: [
-              BoxShadow(
-                color: Colors.grey.shade300.withOpacity(0.5),
-                spreadRadius: 2,
-                blurRadius: 8,
-                offset: Offset(0, 2), // changes position of shadow
-              )
-            ],
-            color: Colors.white,
-            borderRadius:
-                BorderRadius.all(Radius.circular(LUTheme.cardBorderRadius))),
-        child: Stack(
-          children: <Widget>[
-            Positioned.fill(
-              child: ClipRRect(
-                borderRadius:
-                    BorderRadius.circular(LUTheme.cardBorderRadius - 4),
-                child: FadeInImage.assetNetwork(
-                  placeholder: Images.verticalPlaceholder,
-                  image: 'https://picsum.photos/400/300?random=2',
-                  fit: BoxFit.cover,
-                ),
-              ),
-            ),
-            Center(
-              child: Icon(
-                Icons.camera_alt,
-                size: 80,
-                color: LUColors.smoothGray.withOpacity(0.9),
-              ),
-            ),
-          ],
-        ),
-      );
 
   Widget buildEditProfileHeader(BuildContext context) => Container(
         height: MediaQuery.of(context).size.height * headerHeightFactor + 32,
@@ -124,7 +86,9 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                     child: Row(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: <Widget>[
-                        buildAvatar(),
+                        LURectangleAvatar(
+                            editable: true,
+                            profilePictureSize: profilePictureSize),
                         Padding(
                           padding: const EdgeInsets.only(bottom: 24, top: 24),
                           child: Padding(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -2,6 +2,7 @@ import 'package:dr_app/components/buttons/solid_button.dart';
 import 'package:dr_app/components/input_field.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/screens/signup_screen.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
 import 'package:dr_app/utils/styles.dart';
@@ -58,7 +59,8 @@ class _LoginScreenState extends State<LoginScreen> {
                   FlatButton(
                     padding: const EdgeInsets.symmetric(
                         vertical: 0.0, horizontal: 4.0),
-                    onPressed: () {},
+                    onPressed: () =>
+                        Navigator.of(context).pushNamed(SignUpScreen.id),
                     child: Text(
                       'Sign Up',
                       style: Styles.loginFooterText

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dr_app/components/buttons/solid_button.dart';
 import 'package:dr_app/components/cards/tile_option_card.dart';
 import 'package:dr_app/components/list.dart';
+import 'package:dr_app/components/round_avatar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/screens/edit_profile_screen.dart';
 import 'package:dr_app/screens/favorites_screen.dart';
@@ -83,32 +84,8 @@ class ProfileScreen extends StatelessWidget {
                     child: Row(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: <Widget>[
-                        Container(
-                          width: profilePictureSize,
-                          height: profilePictureSize,
-                          padding: const EdgeInsets.all(8),
-                          decoration: BoxDecoration(
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Colors.grey.shade300.withOpacity(0.5),
-                                  spreadRadius: 2,
-                                  blurRadius: 8,
-                                  offset: Offset(
-                                      0, 2), // changes position of shadow
-                                )
-                              ],
-                              color: Colors.white,
-                              borderRadius: BorderRadius.all(
-                                  Radius.circular(LUTheme.cardBorderRadius))),
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(
-                                LUTheme.cardBorderRadius - 4),
-                            child: FadeInImage.assetNetwork(
-                              placeholder: Images.verticalPlaceholder,
-                              image: 'https://picsum.photos/400/300?random=2',
-                              fit: BoxFit.cover,
-                            ),
-                          ),
+                        LURectangleAvatar(
+                          profilePictureSize: profilePictureSize,
                         ),
                         Padding(
                           padding: const EdgeInsets.only(bottom: 24, top: 24),

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,0 +1,55 @@
+import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/utils/colors.dart';
+import 'package:dr_app/utils/images.dart';
+import 'package:flutter/material.dart';
+
+/// The SignUpScreen presents the user with a form which
+/// can be used to create a new account.
+class SignUpScreen extends StatefulWidget {
+  static const id = 'signup_screen';
+
+  @override
+  _SignUpScreenState createState() => _SignUpScreenState();
+}
+
+class _SignUpScreenState extends State<SignUpScreen> {
+  static const headerHeightFactor = 0.28;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: LUTheme.of(context).backgroundColor,
+      child: Stack(
+        children: <Widget>[buildHeaderBackground()],
+      ),
+    );
+  }
+
+  Widget buildHeaderBackground() {
+    return Container(
+      decoration: BoxDecoration(
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.shade300.withOpacity(0.5),
+            spreadRadius: 2,
+            blurRadius: 8,
+            offset: Offset(0, 2), // changes position of shadow
+          )
+        ],
+      ),
+      child: ClipRRect(
+        child: Container(
+          height: MediaQuery.of(context).size.height * headerHeightFactor,
+          color: LUColors.yellow,
+          child: Stack(
+            children: <Widget>[
+              Positioned.fill(
+                  child: Image.asset(Images.homeHeaderBackground,
+                      fit: BoxFit.cover)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dr_app/components/round_avatar.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/utils/colors.dart';
@@ -15,19 +16,38 @@ class SignUpScreen extends StatefulWidget {
 
 class _SignUpScreenState extends State<SignUpScreen> {
   static const headerHeightFactor = 0.28;
+  static const double profilePictureSize = 160;
 
   @override
   Widget build(BuildContext context) {
+    final header = <Widget>[
+      buildSignUpHeaderBackground(),
+      SafeArea(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: Padding(
+            padding: EdgeInsets.only(
+                top: MediaQuery.of(context).size.height *
+                    (headerHeightFactor / 3)),
+            child: LURectangleAvatar(
+              editable: true,
+              profilePictureSize: profilePictureSize,
+            ),
+          ),
+        ),
+      ),
+      SafeArea(
+        child: LUTopBar(
+          title: 'Sign Up',
+          onNavigationButtonPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+    ];
+
     return Container(
       color: LUTheme.of(context).backgroundColor,
       child: Stack(
-        children: <Widget>[
-          buildSignUpHeaderBackground(),
-          LUTopBar(
-            title: 'Sign Up',
-            onNavigationButtonPressed: () => Navigator.of(context).pop(),
-          ),
-        ],
+        children: <Widget>[...header],
       ),
     );
   }

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/utils/colors.dart';
 import 'package:dr_app/utils/images.dart';
@@ -20,12 +21,18 @@ class _SignUpScreenState extends State<SignUpScreen> {
     return Container(
       color: LUTheme.of(context).backgroundColor,
       child: Stack(
-        children: <Widget>[buildHeaderBackground()],
+        children: <Widget>[
+          buildSignUpHeaderBackground(),
+          LUTopBar(
+            title: 'Sign Up',
+            onNavigationButtonPressed: () => Navigator.of(context).pop(),
+          ),
+        ],
       ),
     );
   }
 
-  Widget buildHeaderBackground() {
+  Widget buildSignUpHeaderBackground() {
     return Container(
       decoration: BoxDecoration(
         boxShadow: [

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,4 +1,8 @@
+import 'package:dr_app/components/buttons/solid_button.dart';
+import 'package:dr_app/components/input_field.dart';
+import 'package:dr_app/components/list.dart';
 import 'package:dr_app/components/round_avatar.dart';
+import 'package:dr_app/components/round_container.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:dr_app/utils/colors.dart';
@@ -14,40 +18,40 @@ class SignUpScreen extends StatefulWidget {
   _SignUpScreenState createState() => _SignUpScreenState();
 }
 
+//TODO: State management and validation
 class _SignUpScreenState extends State<SignUpScreen> {
   static const headerHeightFactor = 0.28;
   static const double profilePictureSize = 160;
 
   @override
   Widget build(BuildContext context) {
-    final header = <Widget>[
-      buildSignUpHeaderBackground(),
-      SafeArea(
-        child: Align(
-          alignment: Alignment.topCenter,
-          child: Padding(
-            padding: EdgeInsets.only(
-                top: MediaQuery.of(context).size.height *
-                    (headerHeightFactor / 3)),
-            child: LURectangleAvatar(
-              editable: true,
-              profilePictureSize: profilePictureSize,
-            ),
-          ),
-        ),
-      ),
-      SafeArea(
-        child: LUTopBar(
-          title: 'Sign Up',
-          onNavigationButtonPressed: () => Navigator.of(context).pop(),
-        ),
-      ),
-    ];
-
     return Container(
       color: LUTheme.of(context).backgroundColor,
       child: Stack(
-        children: <Widget>[...header],
+        children: <Widget>[
+          buildSignUpHeaderBackground(),
+          buildSignUpBody(context),
+          SafeArea(
+            child: Align(
+              alignment: Alignment.topCenter,
+              child: Padding(
+                padding: EdgeInsets.only(
+                    top: MediaQuery.of(context).size.height *
+                        (headerHeightFactor / 3)),
+                child: LURectangleAvatar(
+                  editable: true,
+                  profilePictureSize: profilePictureSize,
+                ),
+              ),
+            ),
+          ),
+          SafeArea(
+            child: LUTopBar(
+              title: 'Sign Up',
+              onNavigationButtonPressed: () => Navigator.of(context).pop(),
+            ),
+          )
+        ],
       ),
     );
   }
@@ -76,6 +80,47 @@ class _SignUpScreenState extends State<SignUpScreen> {
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Widget buildSignUpBody(BuildContext context) {
+    return RoundContainer(
+      child: LUList(
+        padding: EdgeInsets.only(
+            top: profilePictureSize / 2, left: 32.0, right: 32.0),
+        items: <Widget>[
+          Form(
+            child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  LUInputField(
+                    fieldTitle: 'Full Name',
+                    hintText: 'Amanda Baggins',
+                    keyboardType: TextInputType.text,
+                  ),
+                  LUInputField(
+                      fieldTitle: 'Email',
+                      hintText: 'amanda@email.com',
+                      keyboardType: TextInputType.emailAddress),
+                  LUInputField(
+                      obscureText: true,
+                      fieldTitle: 'Password',
+                      hintText: '123456',
+                      keyboardType: TextInputType.text),
+                  LUInputField(
+                      obscureText: true,
+                      fieldTitle: 'Repeat Password',
+                      hintText: '123456',
+                      keyboardType: TextInputType.text),
+                ]),
+          ),
+          LUSolidButton(
+            margin: EdgeInsets.only(top: 24.0),
+            title: 'Sign Up',
+            onPressed: () => Navigator.of(context).pop(),
+          )
+        ],
       ),
     );
   }


### PR DESCRIPTION
# Basic Sign Up Screen

**Results**
<img width="470" alt="Screenshot 2020-08-04 at 13 39 30" src="https://user-images.githubusercontent.com/11461969/89294925-1b32c680-d658-11ea-95d9-d6359d97330e.png">

**Highlights**
- Create the `SignUpScreen` and register its route
- Extract avatar picture to `LURectangleAvatar` widget

**Notes**
- Add state management and validation in the future
- Please disregard the the bottom bar -- it will be adjusted in the future