### PR TITLE
#67 More Screen

### DIFF
--- a/lib/components/information_tile.dart
+++ b/lib/components/information_tile.dart
@@ -1,0 +1,24 @@
+import 'package:dr_app/utils/colors.dart';
+import 'package:dr_app/utils/styles.dart';
+import 'package:flutter/material.dart';
+
+/// Simple customised container with a material [Text] widget in it.
+class LUInformationTile extends StatelessWidget {
+  final String text;
+
+  const LUInformationTile({Key key, this.text}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        height: 56,
+        decoration: BoxDecoration(
+            color: LUColors.transparentLightGray,
+            borderRadius: BorderRadius.circular(16.0)),
+        child: Center(
+            child: Text(
+          text,
+          style: Styles.informativeText.copyWith(color: LUColors.gray),
+        )));
+  }
+}

--- a/lib/configs/routes.dart
+++ b/lib/configs/routes.dart
@@ -1,3 +1,4 @@
+import 'package:dr_app/screens/about_version_screen.dart';
 import 'package:dr_app/screens/add_credit_card_screen.dart';
 import 'package:dr_app/screens/category_detail_screen.dart';
 import 'package:dr_app/screens/cuisine_screen.dart';
@@ -38,6 +39,7 @@ final Map<String, WidgetBuilder> routes = {
   LoginScreen.id: (context) => LoginScreen(),
   SignUpScreen.id: (context) => SignUpScreen(),
   PasswordRecoveryScreen.id: (context) => PasswordRecoveryScreen(),
+  AboutVersionScreen.id: (context) => AboutVersionScreen()
 };
 
 final Set<String> fullScreenRoutes = {ScannerScreen.id};

--- a/lib/screens/about_version_screen.dart
+++ b/lib/screens/about_version_screen.dart
@@ -13,6 +13,17 @@ class AboutVersionScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final titlePadding = EdgeInsets.only(left: 4.0, bottom: 8.0);
 
+    List<Widget> getLibraryTiles() {
+      return List.generate(
+          50,
+          (index) => Padding(
+                padding: const EdgeInsets.only(bottom: 4.0),
+                child: LUInformationTile(
+                  text: "Library $index",
+                ),
+              ));
+    }
+
     return Container(
         color: LUTheme.of(context).backgroundColor,
         child: SafeArea(
@@ -38,20 +49,10 @@ class AboutVersionScreen extends StatelessWidget {
                         titlePadding: titlePadding,
                         child: LUInformationTile(text: 'Pedro Belfort')),
                     LUSection(
-                        title: 'Author',
+                        title: 'Open Source Libraries',
                         titlePadding: titlePadding,
                         // TODO: Adjust spacing and border
-                        child: Column(
-                          children: <Widget>[
-                            LUInformationTile(text: 'Library 1'),
-                            LUInformationTile(text: 'Library 2'),
-                            LUInformationTile(text: 'Library 3'),
-                            LUInformationTile(text: 'Library 4'),
-                            LUInformationTile(text: 'Library 5'),
-                            LUInformationTile(text: 'Library 6'),
-                            LUInformationTile(text: 'Library 7'),
-                          ],
-                        )),
+                        child: Column(children: getLibraryTiles())),
                   ],
                 ),
               )

--- a/lib/screens/about_version_screen.dart
+++ b/lib/screens/about_version_screen.dart
@@ -11,6 +11,8 @@ class AboutVersionScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final titlePadding = EdgeInsets.only(left: 4.0, bottom: 8.0);
+
     return Container(
         color: LUTheme.of(context).backgroundColor,
         child: SafeArea(
@@ -25,10 +27,33 @@ class AboutVersionScreen extends StatelessWidget {
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                child: LUSection(
-                    title: 'Version',
-                    titlePadding: EdgeInsets.only(left: 4.0, bottom: 8.0),
-                    child: LUInformationTile(text: '0.0.1 | 32')),
+                child: Column(
+                  children: <Widget>[
+                    LUSection(
+                        title: 'Version',
+                        titlePadding: titlePadding,
+                        child: LUInformationTile(text: '0.0.1 | 32')),
+                    LUSection(
+                        title: 'Author',
+                        titlePadding: titlePadding,
+                        child: LUInformationTile(text: 'Pedro Belfort')),
+                    LUSection(
+                        title: 'Author',
+                        titlePadding: titlePadding,
+                        // TODO: Adjust spacing and border
+                        child: Column(
+                          children: <Widget>[
+                            LUInformationTile(text: 'Library 1'),
+                            LUInformationTile(text: 'Library 2'),
+                            LUInformationTile(text: 'Library 3'),
+                            LUInformationTile(text: 'Library 4'),
+                            LUInformationTile(text: 'Library 5'),
+                            LUInformationTile(text: 'Library 6'),
+                            LUInformationTile(text: 'Library 7'),
+                          ],
+                        )),
+                  ],
+                ),
               )
             ])));
   }

--- a/lib/screens/about_version_screen.dart
+++ b/lib/screens/about_version_screen.dart
@@ -1,3 +1,5 @@
+import 'package:dr_app/components/information_tile.dart';
+import 'package:dr_app/components/section.dart';
 import 'package:dr_app/components/top_bar.dart';
 import 'package:dr_app/configs/theme.dart';
 import 'package:flutter/material.dart';
@@ -20,6 +22,13 @@ class AboutVersionScreen extends StatelessWidget {
                 title: 'About version',
                 buttonBackgroundColor: LUTheme.of(context).primaryColor,
                 tint: LUTheme.of(context).backgroundColor,
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: LUSection(
+                    title: 'Version',
+                    titlePadding: EdgeInsets.only(left: 4.0, bottom: 8.0),
+                    child: LUInformationTile(text: '0.0.1 | 32')),
               )
             ])));
   }

--- a/lib/screens/about_version_screen.dart
+++ b/lib/screens/about_version_screen.dart
@@ -35,6 +35,7 @@ class AboutVersionScreen extends StatelessWidget {
                 title: 'About version',
                 buttonBackgroundColor: LUTheme.of(context).primaryColor,
                 tint: LUTheme.of(context).backgroundColor,
+                onNavigationButtonPressed: () => Navigator.of(context).pop(),
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),

--- a/lib/screens/about_version_screen.dart
+++ b/lib/screens/about_version_screen.dart
@@ -1,0 +1,26 @@
+import 'package:dr_app/components/top_bar.dart';
+import 'package:dr_app/configs/theme.dart';
+import 'package:flutter/material.dart';
+
+/// The AboutVersionScreen displays information about the current
+/// App version such as Author, Version number, and Libraries used.
+class AboutVersionScreen extends StatelessWidget {
+  static const id = 'about_version_screen';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        color: LUTheme.of(context).backgroundColor,
+        child: SafeArea(
+            child: ListView(
+                padding: EdgeInsets.zero,
+                physics: ClampingScrollPhysics(),
+                children: <Widget>[
+              LUTopBar(
+                title: 'About version',
+                buttonBackgroundColor: LUTheme.of(context).primaryColor,
+                tint: LUTheme.of(context).backgroundColor,
+              )
+            ])));
+  }
+}

--- a/lib/screens/more_screen.dart
+++ b/lib/screens/more_screen.dart
@@ -1,10 +1,52 @@
+import 'package:dr_app/components/cards/tile_option_card.dart';
+import 'package:dr_app/components/section.dart';
+import 'package:dr_app/configs/theme.dart';
+import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_vector_icons/flutter_vector_icons.dart';
 
 class MoreScreen extends StatelessWidget {
   static const id = 'more_screen';
 
   @override
   Widget build(BuildContext context) {
-    return Container(child: Center(child: Text('More Screen')));
+    return Container(
+        child: SafeArea(
+            child: ListView(
+      padding: EdgeInsets.only(left: 16.0, right: 16.0, top: 16.0),
+      physics: ClampingScrollPhysics(),
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.only(bottom: 32.0),
+          child: Text('More Settings',
+              style: Styles.topBarTitle
+                  .copyWith(color: LUTheme.of(context).primaryColor)),
+        ),
+        LUSection(
+          titlePadding: EdgeInsets.only(left: 4.0, bottom: 8.0),
+          title: 'General',
+          child: Column(
+            children: <Widget>[
+              LUTileOptionCard(
+                  leadingIcon: FontAwesome5Solid.bell,
+                  title: 'Notifications',
+                  onPressed: () {}),
+              LUTileOptionCard(
+                  leadingIcon: FontAwesome5Solid.user_shield,
+                  title: 'Terms and conditions',
+                  onPressed: () {}),
+              LUTileOptionCard(
+                  leadingIcon: FontAwesome5Solid.star,
+                  title: 'Rate the app',
+                  onPressed: () {}),
+              LUTileOptionCard(
+                  leadingIcon: FontAwesome5Solid.info_circle,
+                  title: 'About this version',
+                  onPressed: () {}),
+            ],
+          ),
+        )
+      ],
+    )));
   }
 }

--- a/lib/screens/more_screen.dart
+++ b/lib/screens/more_screen.dart
@@ -5,6 +5,8 @@ import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_vector_icons/flutter_vector_icons.dart';
 
+/// The More Screen allows the user to view additional
+/// information about the App and configure some of its settings.
 class MoreScreen extends StatelessWidget {
   static const id = 'more_screen';
 
@@ -30,7 +32,13 @@ class MoreScreen extends StatelessWidget {
               LUTileOptionCard(
                   leadingIcon: FontAwesome5Solid.bell,
                   title: 'Notifications',
-                  onPressed: () {}),
+                  trailingChildren: <Widget>[
+                    Switch(
+                      value: false,
+                      onChanged: (value) {},
+                      activeColor: LUTheme.of(context).accentColor,
+                    ),
+                  ]),
               LUTileOptionCard(
                   leadingIcon: FontAwesome5Solid.user_shield,
                   title: 'Terms and conditions',

--- a/lib/screens/more_screen.dart
+++ b/lib/screens/more_screen.dart
@@ -5,6 +5,8 @@ import 'package:dr_app/utils/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_vector_icons/flutter_vector_icons.dart';
 
+import 'about_version_screen.dart';
+
 /// The More Screen allows the user to view additional
 /// information about the App and configure some of its settings.
 class MoreScreen extends StatelessWidget {
@@ -29,6 +31,7 @@ class MoreScreen extends StatelessWidget {
           title: 'General',
           child: Column(
             children: <Widget>[
+              // TODO: Set notifications
               LUTileOptionCard(
                   leadingIcon: FontAwesome5Solid.bell,
                   title: 'Notifications',
@@ -50,7 +53,8 @@ class MoreScreen extends StatelessWidget {
               LUTileOptionCard(
                   leadingIcon: FontAwesome5Solid.info_circle,
                   title: 'About this version',
-                  onPressed: () {}),
+                  onPressed: () =>
+                      Navigator.of(context).pushNamed(AboutVersionScreen.id)),
             ],
           ),
         )

--- a/lib/screens/more_screen.dart
+++ b/lib/screens/more_screen.dart
@@ -33,7 +33,7 @@ class MoreScreen extends StatelessWidget {
                   leadingIcon: FontAwesome5Solid.bell,
                   title: 'Notifications',
                   trailingChildren: <Widget>[
-                    Switch(
+                    Switch.adaptive(
                       value: false,
                       onChanged: (value) {},
                       activeColor: LUTheme.of(context).accentColor,


### PR DESCRIPTION
# More Screen

**Results**
<img width="470" alt="Screenshot 2020-08-08 at 13 32 34" src="https://user-images.githubusercontent.com/11461969/89710509-a6bf9680-d97b-11ea-987e-893f46eb1ae9.png">
<img width="470" alt="Screenshot 2020-08-08 at 13 32 31" src="https://user-images.githubusercontent.com/11461969/89710511-a9ba8700-d97b-11ea-8252-10382b44be6b.png">

**Highlights**
- Create `MoreScreen`
- Create `AboutVersionScreen`
- Register routes and link navigation
- Create `InformationTile` component